### PR TITLE
Fix typo

### DIFF
--- a/cclient/api/examples/example_send_balance.c
+++ b/cclient/api/examples/example_send_balance.c
@@ -34,7 +34,7 @@ void example_send_balance(iota_client_service_t *s) {
                          NUM_TRYTES_TAG);
 
   // value
-  tf.value = 1;  // send 5i to receiver
+  tf.value = 1;  // send 1i to receiver
 
   // message (optional)
   transfer_message_set_string(&tf, "Sending 1i!!");


### PR DESCRIPTION
In this example, we send 1i instead of 5i.