### PR TITLE
add YOCTO option to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,34 +14,37 @@ project(iota_client DESCRIPTION "IOTA Client Library")
 enable_language(C)
 enable_testing()
 
+option(YOCTO "Enable Building in Yocto" OFF)
 option(CCLIENT_TEST "Enable CClient library test cases" OFF)
 
-# fetch iota_common
-include(FetchContent)
-FetchContent_Declare(
-  iota_common
-  GIT_REPOSITORY http://github.com/iotaledger/iota_common.git
-  GIT_TAG 82818daf1ffa31b0f8a247ec51eee5cf68cb79ab
-)
+if(NOT YOCTO)
+  # fetch iota_common
+  include(FetchContent)
+  FetchContent_Declare(
+    iota_common
+    GIT_REPOSITORY http://github.com/iotaledger/iota_common.git
+    GIT_TAG 82818daf1ffa31b0f8a247ec51eee5cf68cb79ab
+  )
 
-if(${CMAKE_VERSION} VERSION_LESS 3.14)
-    macro(FetchContent_MakeAvailable NAME)
-        FetchContent_GetProperties(${NAME})
-        if(NOT ${NAME}_POPULATED)
-            FetchContent_Populate(${NAME})
-            add_subdirectory(${${NAME}_SOURCE_DIR} ${${NAME}_BINARY_DIR})
-        endif()
-    endmacro()
+  if(${CMAKE_VERSION} VERSION_LESS 3.14)
+      macro(FetchContent_MakeAvailable NAME)
+          FetchContent_GetProperties(${NAME})
+          if(NOT ${NAME}_POPULATED)
+              FetchContent_Populate(${NAME})
+              add_subdirectory(${${NAME}_SOURCE_DIR} ${${NAME}_BINARY_DIR})
+          endif()
+      endmacro()
+  endif()
+
+  message(STATUS "Fetching iota_common")
+  FetchContent_MakeAvailable(iota_common)
+
+  # fetch external libs
+  include(ExternalProject)
+  include(cmake/cjson.cmake)
+  include(cmake/http_parser.cmake)
+  include(cmake/mbedtls.cmake)
 endif()
-
-message(STATUS "Fetching iota_common")
-FetchContent_MakeAvailable(iota_common)
-
-# fetch external libs
-include(ExternalProject)
-include(cmake/cjson.cmake)
-include(cmake/http_parser.cmake)
-include(cmake/mbedtls.cmake)
 
 # libs in the sandbox
 link_directories("${CMAKE_INSTALL_PREFIX}/lib")
@@ -168,11 +171,13 @@ add_library(cclient
   ${JSON_SERIALIZER_SRC}
 )
 
-add_dependencies(cclient
-  "ext_cjson"
-  "ext_http_parser"
-  "ext_mbedtls"
-  )
+if(NOT YOCTO)
+  add_dependencies(cclient
+    "ext_cjson"
+    "ext_http_parser"
+    "ext_mbedtls"
+    )
+endif()
 
 target_include_directories(cclient PUBLIC 
   "${PROJECT_SOURCE_DIR}"


### PR DESCRIPTION
this makes integration with the meta-iota Yocto/OpenEmbedded layer easier, as I don't have to patch CMakeLists.txt locally.