### PR TITLE
http client refactoring and support MinGW on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT YOCTO)
   FetchContent_Declare(
     iota_common
     GIT_REPOSITORY http://github.com/iotaledger/iota_common.git
-    GIT_TAG 82818daf1ffa31b0f8a247ec51eee5cf68cb79ab
+    GIT_TAG 1b56a5282933fb674181001630e7b2e2c33b5eea
   )
 
   if(${CMAKE_VERSION} VERSION_LESS 3.14)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,13 +5,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "org_iota_common",
-    commit = "82818daf1ffa31b0f8a247ec51eee5cf68cb79ab",
+    commit = "1b56a5282933fb674181001630e7b2e2c33b5eea",
     remote = "https://github.com/iotaledger/iota_common.git",
 )
 
 git_repository(
     name = "rules_iota",
-    commit = "4fd742195c31b9e2bf859a68cd5de4b2fdba7086",
+    commit = "2d15c55f12cff0db106f45866312f61314c583cd",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 

--- a/cclient/api/examples/cclient_examples.c
+++ b/cclient/api/examples/cclient_examples.c
@@ -56,7 +56,7 @@ int main() {
   logger_init_json_serializer(LOGGER_DEBUG);
 
 #ifdef _USE_HTTP_
-  printf("Connecting to node: http://%s:%u\n", serv.http.host, serv.http.port);
+  printf("Connecting to node: http://%s:%u\n", serv->http.host, serv->http.port);
 #else
   printf("Connecting to node: https://%s:%u\n", serv->http.host, serv->http.port);
 #endif
@@ -79,9 +79,9 @@ int main() {
   /* Extended APIs */
   // example_get_new_address(serv);
   // example_get_inputs(serv);
-  example_get_account_data(serv);
+  // example_get_account_data(serv);
   // example_find_transaction_objects(serv);
-  example_is_promotable(serv);
+  // example_is_promotable(serv);
   // example_get_latest_inclusion(serv);
   // example_send_trytes(serv);
   // example_traverse_bundle(serv);
@@ -89,7 +89,7 @@ int main() {
   // example_replay_bundle(serv);
   // example_broadcast_bundle(serv);
   // example_promote_transaction(serv);
-  example_get_unspent_address(serv);
+  // example_get_unspent_address(serv);
 
   /* Send data and balance */
   // example_send_data(serv);

--- a/cclient/api/examples/example_send_balance.c
+++ b/cclient/api/examples/example_send_balance.c
@@ -34,7 +34,7 @@ void example_send_balance(iota_client_service_t *s) {
                          NUM_TRYTES_TAG);
 
   // value
-  tf.value = 1;  // send 5i to receiver
+  tf.value = 1;  // send 1i to receiver
 
   // message (optional)
   transfer_message_set_string(&tf, "Sending 1i!!");

--- a/cclient/http/BUILD
+++ b/cclient/http/BUILD
@@ -41,10 +41,7 @@ cc_library(
     srcs = ["socket.c"],
     hdrs = ["socket.h"],
     deps = [
-        "@org_iota_common//common:errors",
         "@mbedtls",
-    ] + select({
-        ":windows_platform": ["//utils:windows"],
-        "//conditions:default": [],
-    }),
+        "@org_iota_common//common:errors",
+    ],
 )

--- a/cclient/http/socket.c
+++ b/cclient/http/socket.c
@@ -12,7 +12,13 @@
 // socket receiving timeout
 #define MBEDTLS_SOCKET_TIMEOUT 30000
 
-static void mbedtls_conf_init(mbedtls_ctx_t *tls_ctx, bool is_https) {
+/**
+ * @brief Setup mbedtls configurations
+ *
+ * @param tls_ctx[in] mbedtls context
+ * @param is_https[in] true for HTTPS connunication, false for HTTP
+ */
+static void init_mbedtls_conf(mbedtls_ctx_t *tls_ctx, bool is_https) {
   if (is_https) {
     // init tls stuffs
     mbedtls_entropy_init(&tls_ctx->entropy);
@@ -27,7 +33,12 @@ static void mbedtls_conf_init(mbedtls_ctx_t *tls_ctx, bool is_https) {
   tls_ctx->enable_tls = is_https;
 }
 
-static void mbedtls_conf_destroy(mbedtls_ctx_t *tls_ctx) {
+/**
+ * @brief Clean up mbedtls configurations
+ *
+ * @param tls_ctx[in] mbedtls context
+ */
+static void destory_mbedtls_conf(mbedtls_ctx_t *tls_ctx) {
   if (tls_ctx->enable_tls) {
     mbedtls_entropy_free(&tls_ctx->entropy);
     mbedtls_ctr_drbg_free(&tls_ctx->ctr_drbg);
@@ -40,7 +51,7 @@ static void mbedtls_conf_destroy(mbedtls_ctx_t *tls_ctx) {
   mbedtls_net_free(&tls_ctx->net_ctx);
 }
 
-void mbedtls_socket_close(mbedtls_ctx_t *tls_ctx) { mbedtls_conf_destroy(tls_ctx); }
+void mbedtls_socket_close(mbedtls_ctx_t *tls_ctx) { destory_mbedtls_conf(tls_ctx); }
 
 int mbedtls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size) {
   if (ctx->enable_tls) {
@@ -63,7 +74,7 @@ int mbedtls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t po
   char port_string[6];
   sprintf(port_string, "%d", port);
 
-  mbedtls_conf_init(tls_ctx, ca_pem == NULL ? false : true);
+  init_mbedtls_conf(tls_ctx, ca_pem == NULL ? false : true);
   // init http socket
   if (!tls_ctx->enable_tls) {
     // Start the connection

--- a/cclient/http/socket.c
+++ b/cclient/http/socket.c
@@ -5,168 +5,156 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "socket.h"
 
-int socket_connect(char const *const hostname, const size_t port) {
-  struct addrinfo hints, *serverinfo, *info;
-  char port_string[6] = {};
-  int sockfd = -1;
+// socket receiving timeout
+#define MBEDTLS_SOCKET_TIMEOUT 30000
 
-  memset(&hints, 0, sizeof hints);
-  hints.ai_family = AF_UNSPEC;  // use AF_INET6 to force IPv6
-  hints.ai_socktype = SOCK_STREAM;
-  sprintf(port_string, "%zu", port);
-  if (getaddrinfo(hostname, port_string, &hints, &serverinfo) != 0) {
-    return -1;
+static void mbedtls_conf_init(mbedtls_ctx_t *tls_ctx, bool is_https) {
+  if (is_https) {
+    // init tls stuffs
+    mbedtls_entropy_init(&tls_ctx->entropy);
+    mbedtls_ctr_drbg_init(&tls_ctx->ctr_drbg);
+    mbedtls_ssl_init(&tls_ctx->ssl);
+    mbedtls_ssl_config_init(&tls_ctx->ssl_conf);
+    mbedtls_x509_crt_init(&tls_ctx->cacert);
+    mbedtls_x509_crt_init(&tls_ctx->client_cacert);
+    mbedtls_pk_init(&tls_ctx->pk_ctx);
   }
-  // loop through all the results and connect to the first we can
-  for (info = serverinfo; info; info = info->ai_next) {
-    if ((sockfd = socket(info->ai_family, info->ai_socktype, info->ai_protocol)) == -1) {
-      continue;
-    }
-    if (connect(sockfd, info->ai_addr, info->ai_addrlen) == -1) {
-      close(sockfd);
-      continue;
-    }
-    // Successfully connection
-    break;
-  }
-
-  // Free resources allocated by getaddrinfo
-  freeaddrinfo(serverinfo);
-
-  // If no info was found return error
-  if (!info) {
-    return -1;
-  }
-
-  // Return socket fd - 0 or greater
-  return sockfd;
-}
-
-static void tls_init(mbedtls_ctx_t *tls_ctx) {
-  mbedtls_entropy_init(&tls_ctx->entropy);
-  mbedtls_ctr_drbg_init(&tls_ctx->ctr_drbg);
-  mbedtls_ssl_init(&tls_ctx->ssl);
-  mbedtls_ssl_config_init(&tls_ctx->ssl_conf);
-  mbedtls_x509_crt_init(&tls_ctx->cacert);
-  mbedtls_x509_crt_init(&tls_ctx->client_cacert);
-  mbedtls_pk_init(&tls_ctx->pk_ctx);
   mbedtls_net_init(&tls_ctx->net_ctx);
+  tls_ctx->enable_tls = is_https;
 }
 
-static void tls_destroy(mbedtls_ctx_t *tls_ctx) {
-  mbedtls_entropy_free(&tls_ctx->entropy);
-  mbedtls_ctr_drbg_free(&tls_ctx->ctr_drbg);
-  mbedtls_ssl_free(&tls_ctx->ssl);
-  mbedtls_ssl_config_free(&tls_ctx->ssl_conf);
-  mbedtls_x509_crt_free(&tls_ctx->cacert);
-  mbedtls_x509_crt_free(&tls_ctx->client_cacert);
-  mbedtls_pk_free(&tls_ctx->pk_ctx);
+static void mbedtls_conf_destroy(mbedtls_ctx_t *tls_ctx) {
+  if (tls_ctx->enable_tls) {
+    mbedtls_entropy_free(&tls_ctx->entropy);
+    mbedtls_ctr_drbg_free(&tls_ctx->ctr_drbg);
+    mbedtls_ssl_free(&tls_ctx->ssl);
+    mbedtls_ssl_config_free(&tls_ctx->ssl_conf);
+    mbedtls_x509_crt_free(&tls_ctx->cacert);
+    mbedtls_x509_crt_free(&tls_ctx->client_cacert);
+    mbedtls_pk_free(&tls_ctx->pk_ctx);
+  }
   mbedtls_net_free(&tls_ctx->net_ctx);
 }
 
-void tls_socket_close(mbedtls_ctx_t *tls_ctx) { tls_destroy(tls_ctx); }
+void mbedtls_socket_close(mbedtls_ctx_t *tls_ctx) { mbedtls_conf_destroy(tls_ctx); }
 
-int tls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size) {
-  return mbedtls_ssl_write(&ctx->ssl, (const unsigned char *)data, size);
+int mbedtls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size) {
+  if (ctx->enable_tls) {
+    return mbedtls_ssl_write(&ctx->ssl, (const unsigned char *)data, size);
+  } else {
+    return mbedtls_net_send(&ctx->net_ctx.fd, (const unsigned char *)data, size);
+  }
 }
 
-int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size) {
-  return mbedtls_ssl_read(&ctx->ssl, (unsigned char *)data, size);
+int mbedtls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size) {
+  if (ctx->enable_tls) {
+    return mbedtls_ssl_read(&ctx->ssl, (unsigned char *)data, size);
+  } else {
+    return mbedtls_net_recv_timeout(&ctx->net_ctx.fd, (unsigned char *)data, size, MBEDTLS_SOCKET_TIMEOUT);
+  }
 }
 
-int tls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
-                       char const *client_cert_pem, char const *client_pk_pem, retcode_t *error) {
-  int mbedtls_ret = -1;
-  char const drgb_pres[] = "iota_tls_client";
-  bool is_client_auth = false;
-  char port_string[6] = {};
+int mbedtls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
+                           char const *client_cert_pem, char const *client_pk_pem, retcode_t *error) {
+  char port_string[6];
   sprintf(port_string, "%d", port);
 
-  tls_init(tls_ctx);
-
-  // init RNG
-  if (mbedtls_ctr_drbg_seed(&tls_ctx->ctr_drbg, mbedtls_entropy_func, &tls_ctx->entropy,
-                            (unsigned char const *)drgb_pres, strlen(drgb_pres)) != 0) {
-    *error = RC_UTILS_SOCKET_TLS_RNG;
-    return -1;
-  }
-
-  // parsing CA
-  if (ca_pem) {
-    if (mbedtls_x509_crt_parse(&tls_ctx->cacert, (unsigned char *)ca_pem, strlen(ca_pem) + 1) != 0) {
-      *error = RC_UTILS_SOCKET_TLS_CA;
+  mbedtls_conf_init(tls_ctx, ca_pem == NULL ? false : true);
+  // init http socket
+  if (!tls_ctx->enable_tls) {
+    // Start the connection
+    if (mbedtls_net_connect(&tls_ctx->net_ctx, host, port_string, MBEDTLS_NET_PROTO_TCP) != 0) {
+      *error = RC_UTILS_SOCKET_CONNECT;
       return -1;
     }
-  }
+    *error = RC_OK;
+    return tls_ctx->net_ctx.fd;
 
-  // parsing client CA and PK if it exists
-  if ((NULL != client_cert_pem) && (NULL != client_pk_pem)) {
-    if (mbedtls_x509_crt_parse(&tls_ctx->client_cacert, (unsigned char *)client_cert_pem,
-                               strlen(client_cert_pem) + 1) != 0) {
-      *error = RC_UTILS_SOCKET_TLS_CLIENT_PEM;
+  } else {
+    int mbedtls_ret = -1;
+    char const drgb_pres[] = "iota_tls_client";
+    bool is_client_auth = false;
+    // init RNG
+    if (mbedtls_ctr_drbg_seed(&tls_ctx->ctr_drbg, mbedtls_entropy_func, &tls_ctx->entropy,
+                              (unsigned char const *)drgb_pres, strlen(drgb_pres)) != 0) {
+      *error = RC_UTILS_SOCKET_TLS_RNG;
       return -1;
     }
-    if (mbedtls_pk_parse_key(&tls_ctx->pk_ctx, (unsigned char *)client_pk_pem, strlen(client_pk_pem) + 1, NULL, 0) !=
-        0) {
-      *error = RC_UTILS_SOCKET_TLS_CLIENT_PK;
+
+    // parsing CA
+    if (ca_pem) {
+      if (mbedtls_x509_crt_parse(&tls_ctx->cacert, (unsigned char *)ca_pem, strlen(ca_pem) + 1) != 0) {
+        *error = RC_UTILS_SOCKET_TLS_CA;
+        return -1;
+      }
+    }
+
+    // parsing client CA and PK if it exists
+    if ((NULL != client_cert_pem) && (NULL != client_pk_pem)) {
+      if (mbedtls_x509_crt_parse(&tls_ctx->client_cacert, (unsigned char *)client_cert_pem,
+                                 strlen(client_cert_pem) + 1) != 0) {
+        *error = RC_UTILS_SOCKET_TLS_CLIENT_PEM;
+        return -1;
+      }
+      if (mbedtls_pk_parse_key(&tls_ctx->pk_ctx, (unsigned char *)client_pk_pem, strlen(client_pk_pem) + 1, NULL, 0) !=
+          0) {
+        *error = RC_UTILS_SOCKET_TLS_CLIENT_PK;
+        return -1;
+      }
+      is_client_auth = true;
+    }
+
+    // Start the connection
+    if (mbedtls_net_connect(&tls_ctx->net_ctx, host, port_string, MBEDTLS_NET_PROTO_TCP) != 0) {
+      *error = RC_UTILS_SOCKET_CONNECT;
       return -1;
     }
-    is_client_auth = true;
-  }
-
-  // Start the connection
-  if (mbedtls_net_connect(&tls_ctx->net_ctx, host, port_string, MBEDTLS_NET_PROTO_TCP) != 0) {
-    *error = RC_UTILS_SOCKET_CONNECT;
-    return -1;
-  }
-  // client setup
-  if (mbedtls_ssl_config_defaults(&tls_ctx->ssl_conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
-                                  MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
-    *error = RC_UTILS_SOCKET_TLS_CONF;
-    return -1;
-  }
-
-  mbedtls_ssl_conf_ca_chain(&tls_ctx->ssl_conf, &tls_ctx->cacert, NULL);
-  mbedtls_ssl_conf_rng(&tls_ctx->ssl_conf, mbedtls_ctr_drbg_random, &tls_ctx->ctr_drbg);
-  // tls authentication mode
-  mbedtls_ssl_conf_authmode(&tls_ctx->ssl_conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
-
-  if (mbedtls_ssl_setup(&tls_ctx->ssl, &tls_ctx->ssl_conf) != 0) {
-    *error = RC_UTILS_SOCKET_TLS_AUTHMODE;
-    return -1;
-  }
-
-  mbedtls_ssl_set_hostname(&tls_ctx->ssl, host);
-
-  // BIO callbacks
-  mbedtls_ssl_conf_read_timeout(&tls_ctx->ssl_conf, 30000);  // timeout 30s
-  mbedtls_ssl_set_bio(&tls_ctx->ssl, &tls_ctx->net_ctx, mbedtls_net_send, NULL, mbedtls_net_recv_timeout);
-
-  if (is_client_auth) {
-    if (mbedtls_ssl_conf_own_cert(&tls_ctx->ssl_conf, &tls_ctx->client_cacert, &tls_ctx->pk_ctx) != 0) {
-      *error = RC_UTILS_SOCKET_CLIENT_AUTH;
+    // client setup
+    if (mbedtls_ssl_config_defaults(&tls_ctx->ssl_conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+                                    MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
+      *error = RC_UTILS_SOCKET_TLS_CONF;
       return -1;
     }
-  }
 
-  while ((mbedtls_ret = mbedtls_ssl_handshake(&tls_ctx->ssl)) != 0) {
-    if (mbedtls_ret != MBEDTLS_ERR_SSL_WANT_READ && mbedtls_ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
-      // handshake failed
-      *error = RC_UTILS_SOCKET_TLS_HANDSHAKE;
+    mbedtls_ssl_conf_ca_chain(&tls_ctx->ssl_conf, &tls_ctx->cacert, NULL);
+    mbedtls_ssl_conf_rng(&tls_ctx->ssl_conf, mbedtls_ctr_drbg_random, &tls_ctx->ctr_drbg);
+    // tls authentication mode
+    mbedtls_ssl_conf_authmode(&tls_ctx->ssl_conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+
+    if (mbedtls_ssl_setup(&tls_ctx->ssl, &tls_ctx->ssl_conf) != 0) {
+      *error = RC_UTILS_SOCKET_TLS_AUTHMODE;
       return -1;
     }
-  }
 
-  // Verify the server certificate
-  if (tls_ctx->ssl_conf.authmode != MBEDTLS_SSL_VERIFY_NONE) {
-    mbedtls_ssl_get_verify_result(&tls_ctx->ssl);
+    mbedtls_ssl_set_hostname(&tls_ctx->ssl, host);
+
+    // BIO callbacks
+    mbedtls_ssl_conf_read_timeout(&tls_ctx->ssl_conf, MBEDTLS_SOCKET_TIMEOUT);  // timeout 30s
+    mbedtls_ssl_set_bio(&tls_ctx->ssl, &tls_ctx->net_ctx, mbedtls_net_send, NULL, mbedtls_net_recv_timeout);
+
+    if (is_client_auth) {
+      if (mbedtls_ssl_conf_own_cert(&tls_ctx->ssl_conf, &tls_ctx->client_cacert, &tls_ctx->pk_ctx) != 0) {
+        *error = RC_UTILS_SOCKET_CLIENT_AUTH;
+        return -1;
+      }
+    }
+
+    while ((mbedtls_ret = mbedtls_ssl_handshake(&tls_ctx->ssl)) != 0) {
+      if (mbedtls_ret != MBEDTLS_ERR_SSL_WANT_READ && mbedtls_ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+        // handshake failed
+        *error = RC_UTILS_SOCKET_TLS_HANDSHAKE;
+        return -1;
+      }
+    }
+
+    // Verify the server certificate
+    if (tls_ctx->ssl_conf.authmode != MBEDTLS_SSL_VERIFY_NONE) {
+      mbedtls_ssl_get_verify_result(&tls_ctx->ssl);
+    }
+    return tls_ctx->net_ctx.fd;
   }
-  return tls_ctx->net_ctx.fd;
 }

--- a/cclient/http/socket.h
+++ b/cclient/http/socket.h
@@ -8,6 +8,8 @@
 #ifndef __CCLIENT_HTTP_SOCKETS_H__
 #define __CCLIENT_HTTP_SOCKETS_H__
 
+#include <stdbool.h>
+
 #include "mbedtls/certs.h"
 #include "mbedtls/config.h"
 #include "mbedtls/ctr_drbg.h"
@@ -19,38 +21,9 @@
 
 #include "common/errors.h"
 
-// Windows headers
-#ifdef __WIN32__
-#include "utils/windows.h"
-
-#include <ws2tcpip.h>
-
-// ESP headers
-#elif __XTENSA__
-#include "lwip/netdb.h"
-#include "lwip/sockets.h"
-#include "lwip/sys.h"
-// Should cover all POSIX complient platforms
-// Linux, macOS...
-#else
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-int socket_connect(char const *const hostname, const size_t port);
-static inline void socket_close(int sockfd) {
-  if (sockfd != -1) {
-    close(sockfd);
-  }
-}
-static inline int socket_recv(int sockfd, void *buffer, size_t len) { return recv(sockfd, buffer, len, 0); }
-static inline int socket_send(int sockfd, const void *buffer, size_t len) { return send(sockfd, buffer, len, 0); }
 
 typedef struct mbedtls_ctx_s {
   mbedtls_entropy_context entropy;
@@ -61,13 +34,14 @@ typedef struct mbedtls_ctx_s {
   mbedtls_x509_crt client_cacert;
   mbedtls_pk_context pk_ctx;
   mbedtls_net_context net_ctx;
+  bool enable_tls;
 } mbedtls_ctx_t;
 
-int tls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
-                       char const *client_cert_pem, char const *client_pk_pem, retcode_t *error);
-int tls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size);
-int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size);
-void tls_socket_close(mbedtls_ctx_t *tls_ctx);
+int mbedtls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
+                           char const *client_cert_pem, char const *client_pk_pem, retcode_t *error);
+int mbedtls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size);
+int mbedtls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size);
+void mbedtls_socket_close(mbedtls_ctx_t *tls_ctx);
 
 #ifdef __cplusplus
 }

--- a/cclient/http/socket.h
+++ b/cclient/http/socket.h
@@ -25,6 +25,10 @@
 extern "C" {
 #endif
 
+/**
+ * @brief mbedtls context
+ *
+ */
 typedef struct mbedtls_ctx_s {
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
@@ -37,10 +41,45 @@ typedef struct mbedtls_ctx_s {
   bool enable_tls;
 } mbedtls_ctx_t;
 
+/**
+ * @brief create mbedtls network socket
+ *
+ * @param tls_ctx[in] mbedtls context
+ * @param host[in] host address or IP
+ * @param port[in] host port number
+ * @param ca_pem[in] Certificate Authority in pem format
+ * @param client_cert_pem[in] client certificate
+ * @param client_pk_pem[in] client private key
+ * @param error[out] the error code
+ * @return int socket file descriptor
+ */
 int mbedtls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
                            char const *client_cert_pem, char const *client_pk_pem, retcode_t *error);
+/**
+ * @brief socket send implementation
+ *
+ * @param ctx[in] mbedtls context
+ * @param data[in] a buffer holding the data
+ * @param size[in] number of bytes should be sent
+ * @return int the number of bytes actually written
+ */
 int mbedtls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size);
+
+/**
+ * @brief socket receive impelmentation
+ *
+ * @param ctx[in] mbedtls context
+ * @param data[in] data buffer
+ * @param size[in] max number of bytes to read
+ * @return int the number of bytes read.
+ */
 int mbedtls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size);
+
+/**
+ * @brief clean up mbedtls socket
+ *
+ * @param tls_ctx[in] mbedtls context
+ */
 void mbedtls_socket_close(mbedtls_ctx_t *tls_ctx);
 
 #ifdef __cplusplus

--- a/cclient/serialization/json/get_inclusion_states.c
+++ b/cclient/serialization/json/get_inclusion_states.c
@@ -18,7 +18,6 @@ retcode_t json_get_inclusion_states_serialize_request(get_inclusion_states_req_t
     return RC_NULL_PARAM;
   }
 
-  printf("tips = %p, tx = %p \n", req->tips, req->transactions);
   if (!req->transactions) {
     log_error(json_logger_id, "[%s:%d] NULL parameters\n", __func__, __LINE__);
     return RC_NULL_PARAM;


### PR DESCRIPTION
* update iota_common
* fixed compiling issues on example code 
* use mbedtls for both HTTP/HTTPS
* compiled client lib via MinGW in Powershell  on Windows.
` bazelisk.exe build --compiler=mingw-gcc //cclient/...`
