### PR TITLE
API changes on iota_client_get_inclusion_states and iota_client_get_balances

### DIFF
--- a/cclient/api/examples/example_get_balance.c
+++ b/cclient/api/examples/example_get_balance.c
@@ -32,8 +32,6 @@ void example_get_balance(iota_client_service_t *s) {
     goto done;
   }
 
-  balance_req->threshold = 100;
-
   if ((ret_code = iota_client_get_balances(s, balance_req, balance_res)) == RC_OK) {
     hash243_queue_entry_t *q_iter = NULL;
     size_t balance_cnt = get_balances_res_balances_num(balance_res);

--- a/cclient/api/examples/example_get_inclusion_states.c
+++ b/cclient/api/examples/example_get_inclusion_states.c
@@ -10,9 +10,6 @@
 static tryte_t const *const TEST_HASH =
     (tryte_t *)"RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVA";
 
-static tryte_t const *const TEST_TIP =
-    (tryte_t *)"99999999IP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVA";
-
 void example_get_inclusion_states(iota_client_service_t *s) {
   printf("\n[%s]\n", __FUNCTION__);
   flex_trit_t trits_243[FLEX_TRIT_SIZE_243];
@@ -32,16 +29,6 @@ void example_get_inclusion_states(iota_client_service_t *s) {
 
   if ((ret_code = get_inclusion_states_req_hash_add(get_inclusion_req, trits_243)) != RC_OK) {
     printf("Error: adding hash failed.\n");
-    goto done;
-  }
-
-  if (flex_trits_from_trytes(trits_243, NUM_TRITS_HASH, TEST_TIP, NUM_TRYTES_HASH, NUM_TRYTES_HASH) == 0) {
-    printf("Error: converting flex_trit failed\n");
-    goto done;
-  }
-
-  if ((ret_code = get_inclusion_states_req_tip_add(get_inclusion_req, trits_243)) != RC_OK) {
-    printf("Error: adding tip failed.\n");
     goto done;
   }
 

--- a/cclient/api/examples/example_get_transactions_to_approve.c
+++ b/cclient/api/examples/example_get_transactions_to_approve.c
@@ -7,8 +7,8 @@
 
 #include "cclient/api/examples/cclient_examples.h"
 
-static tryte_t const *const REF_HASH =
-    (tryte_t *)"VOPPIXFBHNNEFAAZJLLKTTFMMVJZPHQCTROSU99KYHYBGLJYMCPGIQGSUW9NQQ9TOVTEOKFDCAJLXA999";
+// static tryte_t const *const REF_HASH =
+//     (tryte_t *)"VOPPIXFBHNNEFAAZJLLKTTFMMVJZPHQCTROSU99KYHYBGLJYMCPGIQGSUW9NQQ9TOVTEOKFDCAJLXA999";
 
 void example_get_transactions_to_approve(iota_client_service_t *s) {
   printf("\n[%s]\n", __FUNCTION__);
@@ -22,15 +22,16 @@ void example_get_transactions_to_approve(iota_client_service_t *s) {
     goto done;
   }
 
-  if (flex_trits_from_trytes(reference, NUM_TRITS_HASH, REF_HASH, NUM_TRYTES_HASH, NUM_TRYTES_HASH) == 0) {
-    printf("Error: converting flex_trit failed\n");
-    goto done;
-  }
+  // Reference parameter is optional
+  // if (flex_trits_from_trytes(reference, NUM_TRITS_HASH, REF_HASH, NUM_TRYTES_HASH, NUM_TRYTES_HASH) == 0) {
+  //   printf("Error: converting flex_trit failed\n");
+  //   goto done;
+  // }
 
-  if ((ret = get_transactions_to_approve_req_set_reference(tx_approve_req, reference)) != RC_OK) {
-    printf("Error: OOM on setting reference\n");
-    goto done;
-  }
+  // if ((ret = get_transactions_to_approve_req_set_reference(tx_approve_req, reference)) != RC_OK) {
+  //   printf("Error: OOM on setting reference\n");
+  //   goto done;
+  // }
 
   tx_approve_req->depth = IOTA_CONFIG_NODE_DEPTH;
 

--- a/cclient/api/extended/get_account_data.c
+++ b/cclient/api/extended/get_account_data.c
@@ -95,7 +95,6 @@ retcode_t iota_client_get_account_data(iota_client_service_t const* const serv, 
 
     // get balances
     out_account->balance = 0;
-    balances_req->threshold = 100;  // currently `100` should be used
     balances_req->addresses = out_account->addresses;
     if ((ret_code = iota_client_get_balances(serv, balances_req, balances_res)) == RC_OK) {
       // count all balances

--- a/cclient/api/extended/get_inputs.c
+++ b/cclient/api/extended/get_inputs.c
@@ -62,8 +62,6 @@ retcode_t iota_client_get_inputs(iota_client_service_t const* const serv, flex_t
       }
     }
 
-    balances_req->threshold = 100;  // currently `100` should be used
-
     ret_code = iota_client_get_balances(serv, balances_req, balances_res);
     if (ret_code == RC_OK) {
       // expect balance value is in order.

--- a/cclient/api/extended/prepare_transfers.c
+++ b/cclient/api/extended/prepare_transfers.c
@@ -100,7 +100,6 @@ static retcode_t check_balances(iota_client_service_t const* const serv, inputs_
     goto end;
   }
 
-  balances_req->threshold = 100;
   INPUTS_FOREACH(inputs->input_array, input_elm) {
     if ((ret = get_balances_req_address_add(balances_req, input_elm->address)) != RC_OK) {
       log_error(client_extended_logger_id, "Adding addresses to request is failed.\n");

--- a/cclient/api/tests/test_find_transactions.c
+++ b/cclient/api/tests/test_find_transactions.c
@@ -48,6 +48,7 @@ static void test_find_tx_by_bundle(void) {
   TEST_ASSERT_NULL(find_tx_res);
 }
 
+/*
 static void test_find_tx_by_empty_bundle(void) {
   flex_trit_t flex_hash[NUM_FLEX_TRITS_HASH];
   find_transactions_req_t *find_tx_req = find_transactions_req_new();
@@ -66,6 +67,7 @@ static void test_find_tx_by_empty_bundle(void) {
   find_transactions_res_free(&find_tx_res);
   TEST_ASSERT_NULL(find_tx_res);
 }
+*/
 
 static void test_find_tx_by_address(void) {
   flex_trit_t flex_addr[NUM_FLEX_TRITS_ADDRESS];
@@ -86,6 +88,7 @@ static void test_find_tx_by_address(void) {
   TEST_ASSERT_NULL(find_tx_res);
 }
 
+/*
 static void test_find_tx_by_empty_address(void) {
   flex_trit_t flex_addr[NUM_FLEX_TRITS_ADDRESS];
   find_transactions_req_t *find_tx_req = find_transactions_req_new();
@@ -104,6 +107,7 @@ static void test_find_tx_by_empty_address(void) {
   find_transactions_res_free(&find_tx_res);
   TEST_ASSERT_NULL(find_tx_res);
 }
+*/
 
 static void test_find_tx_by_tag(void) {
   flex_trit_t flex_tag[NUM_FLEX_TRITS_TAG];
@@ -123,6 +127,7 @@ static void test_find_tx_by_tag(void) {
   TEST_ASSERT_NULL(find_tx_res);
 }
 
+/*
 static void test_find_tx_by_empty_tag(void) {
   flex_trit_t flex_tag[NUM_FLEX_TRITS_TAG];
   find_transactions_req_t *find_tx_req = find_transactions_req_new();
@@ -141,6 +146,7 @@ static void test_find_tx_by_empty_tag(void) {
   find_transactions_res_free(&find_tx_res);
   TEST_ASSERT_NULL(find_tx_res);
 }
+*/
 
 static void test_find_tx_by_approvee(void) {
   flex_trit_t flex_hash[NUM_FLEX_TRITS_HASH];
@@ -161,6 +167,7 @@ static void test_find_tx_by_approvee(void) {
   TEST_ASSERT_NULL(find_tx_res);
 }
 
+/*
 static void test_find_tx_by_empty_approvee(void) {
   flex_trit_t flex_hash[NUM_FLEX_TRITS_HASH];
   find_transactions_req_t *find_tx_req = find_transactions_req_new();
@@ -179,6 +186,7 @@ static void test_find_tx_by_empty_approvee(void) {
   find_transactions_res_free(&find_tx_res);
   TEST_ASSERT_NULL(find_tx_res);
 }
+*/
 
 int main() {
   UNITY_BEGIN();
@@ -191,7 +199,7 @@ int main() {
   RUN_TEST(test_find_tx_by_address);
   RUN_TEST(test_find_tx_by_tag);
   RUN_TEST(test_find_tx_by_approvee);
-  // no needed in IRI v1.8.5
+  // IRI v1.8.5 accept empty hashes
   // RUN_TEST(test_find_tx_by_empty_bundle);
   // RUN_TEST(test_find_tx_by_empty_tag);
   // RUN_TEST(test_find_tx_by_empty_address);

--- a/cclient/api/tests/test_get_balances.c
+++ b/cclient/api/tests/test_get_balances.c
@@ -12,7 +12,7 @@ static iota_client_service_t *g_serv;
 static void test_get_balances_empty(void) {
   get_balances_req_t *balance_req = get_balances_req_new();
   TEST_ASSERT_NOT_NULL(balance_req);
-  TEST_ASSERT_EQUAL_INT8(0, balance_req->threshold);
+  TEST_ASSERT_EQUAL_INT8(100, balance_req->threshold);
   TEST_ASSERT_NULL(balance_req->addresses);
   TEST_ASSERT_NULL(balance_req->tips);
 
@@ -42,8 +42,6 @@ static void test_get_balances(void) {
                                      NUM_TRYTES_ADDRESS) != 0);
   TEST_ASSERT_EQUAL_INT16(RC_OK, get_balances_req_address_add(balance_req, flex_addr));
 
-  balance_req->threshold = 100;
-
   TEST_ASSERT_EQUAL_INT16(RC_OK, iota_client_get_balances(g_serv, balance_req, balance_res));
 
   TEST_ASSERT_NOT_NULL(balance_res->references);
@@ -72,8 +70,6 @@ static void test_get_balances_with_tip(void) {
               0);
   TEST_ASSERT_EQUAL_INT16(RC_OK, get_balances_req_tip_add(balance_req, flex_tip));
 
-  balance_req->threshold = 100;
-
   TEST_ASSERT_EQUAL_INT16(RC_OK, iota_client_get_balances(g_serv, balance_req, balance_res));
 
   TEST_ASSERT_NOT_NULL(balance_res->references);
@@ -101,8 +97,6 @@ static void test_get_balances_invalid_tip(void) {
   TEST_ASSERT(flex_trits_from_trytes(flex_tip, NUM_TRITS_HASH, TEST_BUNDLE_HASH_0, NUM_TRYTES_HASH, NUM_TRYTES_HASH) !=
               0);
   TEST_ASSERT_EQUAL_INT16(RC_OK, get_balances_req_tip_add(balance_req, flex_tip));
-
-  balance_req->threshold = 100;
 
   TEST_ASSERT_EQUAL_INT16(RC_CCLIENT_RES_ERROR, iota_client_get_balances(g_serv, balance_req, balance_res));
 

--- a/cclient/request/get_balances.c
+++ b/cclient/request/get_balances.c
@@ -14,7 +14,8 @@ get_balances_req_t* get_balances_req_new() {
   if (req) {
     req->addresses = NULL;
     req->tips = NULL;
-    req->threshold = 0;
+    // for backward compatibility, default to 100
+    req->threshold = 100;
   }
   return req;
 }

--- a/cclient/request/get_balances.h
+++ b/cclient/request/get_balances.h
@@ -30,8 +30,10 @@ extern "C" {
  */
 typedef struct {
   /**
+   * Deprecated since IRI-v1.8.6
+   *
    * The confirmation threshold between 0 and 100(inclusive).
-   *  Should be set to 100 for getting balance by counting only confirmed
+   * Should be set to 100 for getting balance by counting only confirmed
    * transactions.
    */
   uint8_t threshold;

--- a/cclient/request/get_inclusion_states.h
+++ b/cclient/request/get_inclusion_states.h
@@ -34,6 +34,8 @@ typedef struct {
    */
   hash243_queue_t transactions;
   /**
+   * Deprecated since IRI-v1.8.6
+   *
    * List of tips (including milestones) you want to search for the inclusion
    * state.
    */
@@ -85,7 +87,7 @@ static inline flex_trit_t* get_inclusion_states_req_hash_get(get_inclusion_state
 }
 
 /**
- * @brief Add a tip transaction to the request object.
+ * @brief Add a tip transaction to the request object. Deprecated since IRI-v1.8.6
  *
  * @param[in] req The request object.
  * @param[in] hash A tip transaction hash.
@@ -100,7 +102,7 @@ static inline retcode_t get_inclusion_states_req_tip_add(get_inclusion_states_re
 }
 
 /**
- * @brief Get a tip hash by index.
+ * @brief Get a tip hash by index. Deprecated since IRI-v1.8.6
  *
  * @param[in] req The request object.
  * @param[in] index An index of the tip transaction hash list.


### PR DESCRIPTION
# Description of change

Fix #22 
With regard to IRI 1.8.6
* threshold is deprecated in get_balances 
* the tips is deprecated in get_inclusion_states.

## Type of change

- Bug fix 

## How the change has been tested

local test with IRI1.8.6 and Hornet nodes.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
