### PR TITLE
Avoid pointing to a NULL address

### DIFF
--- a/cclient/http/http.c
+++ b/cclient/http/http.c
@@ -120,7 +120,7 @@ static http_buffer_t* http_buffer_new(int len) {
  * @param buf a http_buffer_t object
  */
 static void http_buffer_free(http_buffer_t** buf) {
-  if (buf != NULL) {
+  if (buf != NULL && (*buf) != NULL) {
     if ((*buf)->data) {
       free((*buf)->data);
     }


### PR DESCRIPTION
# Description of change

Avoid pointing to a NULL address of `buf` object. This error would cause SEGV fault when connecting to a failed full node.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
