### PR TITLE
Fix HTTP Chunked-Transfer Encoding parsing

### DIFF
--- a/cclient/http/http.c
+++ b/cclient/http/http.c
@@ -270,9 +270,11 @@ static int parser_on_chunk_header(http_parser* parser) {
   client->response->is_chunked = true;
 
   // there is no content_length in chunked transfer
-  if ((client->res_data = http_buffer_new(CCLIENT_HTTP_BUFFER_SIZE)) == NULL) {
-    client->state = HTTP_STATE_OOM;
-    return -1;
+  if (!client->res_data) {
+    if ((client->res_data = http_buffer_new(CCLIENT_HTTP_BUFFER_SIZE)) == NULL) {
+      client->state = HTTP_STATE_OOM;
+      return -1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
In 'http-parser', http_parser_execute would run the callback functions
for chunked encoding more than one time. Therefore, if we allocate a
new memory for 'parser->data->res_data', then it will cause response
message totally disappear.

See the description in README in [`http-parser`](https://github.com/nodejs/http-parser/blob/master/README.md).

```
In case you parse HTTP message in chunks (i.e. read() request line from socket, parse, read half headers, parse, etc) your data callbacks may be called more than once.
```

# Description of change

I add an if statement to check if a `parser->data->res_data` has been allocated.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run example of `get_trytes` under `api/example`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
