### PR TITLE
Fix derefering to a not available pointer

### DIFF
--- a/cclient/api/core/core_init.c
+++ b/cclient/api/core/core_init.c
@@ -31,6 +31,6 @@ iota_client_service_t *iota_client_core_init(char const *host, uint16_t port, ch
 void iota_client_core_destroy(iota_client_service_t **service) {
   if (service && *service) {
     free(*service);
+    *service = NULL;
   }
-  *service = NULL;
 }


### PR DESCRIPTION
# Description of change

The old way to derefer the pointer may derefer to a not available location, since derefer `service` is out of the checking scope

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run the current CI.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
