### PR TITLE
fix CTest->Unity on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,5 +25,5 @@ Add an `x` to the boxes that are relevant to your changes, and delete any items 
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
+- [ ] I have added tests using [Unity](http://www.throwtheswitch.org/unity) that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
# Description of change

PR template mentioned CTest instead of Unity as test framework.

## Type of change

- Bugfix (a non-breaking change which fixes an issue)
