### PR TITLE
educate API users about seed management

### DIFF
--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -364,6 +364,7 @@ int wallet_send(iota_wallet_t* w, uint32_t sender_index, byte_t receiver[], uint
 
 void wallet_destroy(iota_wallet_t* w) {
   if (w) {
+    sodium_memzero(w->seed, IOTA_ADDRESS_BYTES);
     free(w);
   }
 }


### PR DESCRIPTION
# Description of change

Even though seed management is a responsability of end-user application developer, it is IF duty to educate library users about the dangerous consequences of minsmanaged seeds.
    
This commit improves the wallet_send example with additional comments that educate library users, as well as small modifications to application logic.
    
We also propose the addition of `sodium_memzero()` function call to API call `wallet_destroy()` implementation, ensuring seed is completely erased from memory after wallet is destroyed.

cc @nothingismagick

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Execution of `wallet_send_tx` test fails with the following error message:
```
[wallet_build_transaction:164] Err: input not found
[wallet_build_transaction:198] Err: build tx failed
[wallet_send:318] Err: create transaction payload failed
send tx to atoi1q8dxnfl99slmsakun7pvqmcf5s5ctmzds3f38ehsygkuch4e5jymxuwr09p failed
```

however, it also fails at commit 30b678e8957cd98393ab6265880e2f453be6a69f
so I assume it's from unrelated issues, and PR does not introduce bugs.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
