### PR TITLE
erase seed on wallet_destroy

### DIFF
--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -364,6 +364,7 @@ int wallet_send(iota_wallet_t* w, uint32_t sender_index, byte_t receiver[], uint
 
 void wallet_destroy(iota_wallet_t* w) {
   if (w) {
+    sodium_memzero(w->seed, IOTA_ADDRESS_BYTES);
     free(w);
   }
 }


### PR DESCRIPTION
# Description of change

C applications can have a big attack surface, if not written properly.
Erasing seed from memory doesn't fully avoid potential exploits, but at least reduces attack surface and sets the bar a little higher.

solves #96 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
/home/bernardo/develop/iota.c/build/tests/test_wallet_api
[validate_pib44_path:23] Err: invalid length of path
[wallet_create:205] Err: invalid parameters
[validate_pib44_path:23] Err: invalid length of path
[validate_pib44_path:56] Err: invalid path format: hardened is needed
[validate_pib44_path:65] Err: path format is m/44'/4218'/Account'/Change'
[validate_pib44_path:65] Err: path format is m/44'/4218'/Account'/Change'
[validate_pib44_path:65] Err: path format is m/44'/4218'/Account'/Change'
[validate_pib44_path:56] Err: invalid path format: hardened is needed
[validate_pib44_path:65] Err: path format is m/44'/4218'/Account'/Change'
515582FE648B0F10A2B2A1B91D7502190C979BAABFEE85B6BBB5020692E55D16
BC981BEA9924FE921CF41D7D8C5AE48FB453313FE4A6A1D6E88AC5AE42F0477A
6D9A35E98E2784A043D555E6B171C797B001C2A1495BC49BCE3BF0ABBDF73977
B177FCCC51153E638F6DD628A4A73F11A59408F3EA507F8A58A71FA16D2379A3
48E03225600898784B82DBD72DA1458BDBF63300E29A0203C268E55BF4D05E8F
/home/bernardo/develop/iota.c/tests/wallet/test_wallet.c:103:test_wallet_api:PASS

-----------------------
1 Tests 0 Failures 0 Ignored 
OK
```

I also wrote the following test, but `memcmp` crashes because I don't know how to properly handle dangling pointers:
```
void test_wallet_destroy() {
// create a wallet account
  iota_wallet_t* wallet = wallet_create(seed, "m/44'/4218'/0'/0'");
  TEST_ASSERT_NOT_NULL(wallet);

  byte_t *wallet_seed_addr = wallet->seed;
  wallet_destroy(wallet);

  byte_t null_seed[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
  TEST_ASSERT(memcmp(wallet_seed_addr, null_seed, IOTA_SEED_BYTES) == 0);
}
```

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
