### PR TITLE
SPDX headers

### DIFF
--- a/src/client/api/v1/get_node_info.c
+++ b/src/client/api/v1/get_node_info.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/client/api/v1/get_node_info.h
+++ b/src/client/api/v1/get_node_info.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CLIENT_API_V1_INFO_H__
 #define __CLIENT_API_V1_INFO_H__
 

--- a/src/client/api/v1/response_error.c
+++ b/src/client/api/v1/response_error.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 #include <string.h>
 

--- a/src/client/api/v1/response_error.h
+++ b/src/client/api/v1/response_error.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CLIENT_API_V1_RES_ERR_H__
 #define __CLIENT_API_V1_RES_ERR_H__
 

--- a/src/client/client_service.h
+++ b/src/client/client_service.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CLIENT_SERVICE_H__
 #define __CLIENT_SERVICE_H__
 

--- a/src/client/network/http.h
+++ b/src/client/network/http.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CLIENT_NETWORK_HTTP_H__
 #define __CLIENT_NETWORK_HTTP_H__
 

--- a/src/client/network/http_curl.c
+++ b/src/client/network/http_curl.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __XTENSA__  // workaround: srcFilter is not working in PlatformIO
 #include <curl/curl.h>
 

--- a/src/client/network/http_esp32.c
+++ b/src/client/network/http_esp32.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/core/models/inputs/utxo_input.c
+++ b/src/core/models/inputs/utxo_input.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/core/models/inputs/utxo_input.h
+++ b/src/core/models/inputs/utxo_input.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_MODELS_INPUTS_UTXO_INPUT_H__
 #define __CORE_MODELS_INPUTS_UTXO_INPUT_H__
 

--- a/src/core/models/outputs/sig_unlocked_single_output.c
+++ b/src/core/models/outputs/sig_unlocked_single_output.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/core/models/outputs/sig_unlocked_single_output.h
+++ b/src/core/models/outputs/sig_unlocked_single_output.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_MODELS_OUTPUTS_SIG_UNLOCK_H__
 #define __CORE_MODELS_OUTPUTS_SIG_UNLOCK_H__
 

--- a/src/core/models/payloads/milestone.h
+++ b/src/core/models/payloads/milestone.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_MODELS_PL_MILESTONE_H__
 #define __CORE_MODELS_PL_MILESTONE_H__
 

--- a/src/core/utils/allocator.h
+++ b/src/core/utils/allocator.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_UTILS_ALLOCATOR_H__
 #define __CORE_UTILS_ALLOCATOR_H__
 

--- a/src/core/utils/byte_buffer.c
+++ b/src/core/utils/byte_buffer.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <string.h>
 
 #include "core/utils/allocator.h"

--- a/src/core/utils/byte_buffer.h
+++ b/src/core/utils/byte_buffer.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_UTILS_BYTE_BUFFER_H__
 #define __CORE_UTILS_BYTE_BUFFER_H__
 

--- a/src/core/utils/iota_str.c
+++ b/src/core/utils/iota_str.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include "core/utils/iota_str.h"
 #include "core/utils/allocator.h"
 

--- a/src/core/utils/iota_str.h
+++ b/src/core/utils/iota_str.h
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __CORE_UTILS_IOTA_STR_H__
 #define __CORE_UTILS_IOTA_STR_H__
 

--- a/tests/client/test_http.c
+++ b/tests/client/test_http.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <curl/curl.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/core/test_allocator.c
+++ b/tests/core/test_allocator.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 #include <string.h>
 #include <unity/unity.h>

--- a/tests/core/test_byte_buffer.c
+++ b/tests/core/test_byte_buffer.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 #include <string.h>
 

--- a/tests/core/test_inputs.c
+++ b/tests/core/test_inputs.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 
 #include "core/models/inputs/utxo_input.h"

--- a/tests/core/test_iota_str.c
+++ b/tests/core/test_iota_str.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 
 #include "core/utils/iota_str.h"

--- a/tests/core/test_outputs.c
+++ b/tests/core/test_outputs.c
@@ -1,3 +1,6 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 
 #include "core/models/outputs/sig_unlocked_single_output.h"


### PR DESCRIPTION
# Description of change

adds SPDX identifier in source files
updates old years (`2019`, `2020`) to `2021`

solves #60 

## Type of change

- Bugfix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Documentation fix

## How the change has been tested

Visual inspection was done over files that didn't have SPDX headers.
`find` and `sed` were used to recursively replace `2019` and `2020` with `2021`.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
