### PR TITLE
Core - sign tx with essence hash

### DIFF
--- a/src/client/api/v1/send_message.c
+++ b/src/client/api/v1/send_message.c
@@ -14,6 +14,7 @@ int serialize_indexation(message_t* msg, byte_buf_t* buf) {
   int ret = -1;
   cJSON* json_root = cJSON_CreateObject();
   byte_buf_t* hex_data = NULL;
+  byte_buf_t* hex_index = NULL;
   char* json_string = NULL;
   if (!json_root) {
     printf("[%s:%d] create json root object failed\n", __func__, __LINE__);
@@ -52,8 +53,13 @@ int serialize_indexation(message_t* msg, byte_buf_t* buf) {
       goto end;
     }
 
-    if (!cJSON_AddStringToObject(json_payload, JSON_KEY_INDEX, (char const* const)payload->index->data)) {
-      printf("[%s:%d] payload/index object failed\n", __func__, __LINE__);
+    if ((hex_index = byte_buf_str2hex(payload->index)) != NULL) {
+      if (!cJSON_AddStringToObject(json_payload, JSON_KEY_INDEX, (char const* const)hex_index->data)) {
+        printf("[%s:%d] payload/index object failed\n", __func__, __LINE__);
+        goto end;
+      }
+    } else {
+      printf("[%s:%d] payload/index serialization failed\n", __func__, __LINE__);
       goto end;
     }
 
@@ -91,6 +97,7 @@ int serialize_indexation(message_t* msg, byte_buf_t* buf) {
 end:
   cJSON_Delete(json_root);
   byte_buf_free(hex_data);
+  byte_buf_free(hex_index);
   if (json_string) {
     free(json_string);
   }

--- a/src/crypto/iota_crypto.h
+++ b/src/crypto/iota_crypto.h
@@ -14,6 +14,8 @@
 #define CRYPTO_SHA512_KEY_BYTES 32   // crypto_auth_hmacsha512_KEYBYTES
 #define CRYPTO_SHA512_HASH_BYTES 64  // crypto_auth_hmacsha512_BYTES
 
+#define CRYPTO_BLAKE2B_HASH_BYTES 32  // crypto_generichash_blake2b_BYTES
+
 typedef struct {
   uint8_t pub[ED_PUBLIC_KEY_BYTES];
   uint8_t priv[ED_PRIVATE_KEY_BYTES];

--- a/tests/client/api_v1/test_send_message.c
+++ b/tests/client/api_v1/test_send_message.c
@@ -52,8 +52,8 @@ void test_serialize_indexation() {
   char const* const index = "iota.c";
   char const* const exp_msg =
       "{\"networkId\":\"\",\"parentMessageIds\":[\"7f471d9bb0985e114d78489cfbaf1fb3896931bdc03c89935bacde5b9fbc86ff\","
-      "\"3b4354521ade76145b5616a414fa283fcdb7635ee627a42ecb2f75135e18f10f\"],\"payload\":{\"type\":2,\"index\":\"iota."
-      "c\",\"data\":\"48656C6C6F\"},\"nonce\":\"\"}";
+      "\"3b4354521ade76145b5616a414fa283fcdb7635ee627a42ecb2f75135e18f10f\"],\"payload\":{\"type\":2,\"index\":"
+      "\"696F74612E63\",\"data\":\"48656C6C6F\"},\"nonce\":\"\"}";
 
   message_t* msg = api_message_new();
   TEST_ASSERT_NOT_NULL(msg);
@@ -155,8 +155,8 @@ void test_send_core_message_tx() {
   // no needed
   res_outputs_address_free(res);
 
-  // create output for sending 1Ki out
-  uint64_t token_send = 1000;
+  // create output for sending 10Mi out
+  uint64_t token_send = 10000000;
   TEST_ASSERT(tx_payload_add_output(tx_payload, wallet_addr, token_send) == 0);
   TEST_ASSERT(tx_payload_add_output(tx_payload, genesis_addr, total - token_send) == 0);
 

--- a/tests/client/test_message_builder.c
+++ b/tests/client/test_message_builder.c
@@ -11,7 +11,7 @@ void test_msg_indexation() {
       "{\"networkId\":null,\"parentMessageIds\":[\"0000000000000000000000000000000000000000000000000000000000000000\","
       "\"0000000000000000000000000000000000000000000000000000000000000000\","
       "\"0000000000000000000000000000000000000000000000000000000000000000\"],\"payload\":{\"type\":2,\"index\":"
-      "\"HELLO\",\"data\":\"48454C4C4F\"},\"nonce\":null}";
+      "\"48454C4C4F\",\"data\":\"48454C4C4F\"},\"nonce\":null}";
 
   byte_t idx_data[5] = {0x48, 0x45, 0x4C, 0x4C, 0x4F};
   byte_t empty_parent[IOTA_MESSAGE_ID_BYTES] = {};
@@ -42,10 +42,10 @@ void test_msg_tx() {
       "\"type\":0,\"inputs\":[{\"type\":0,\"transactionId\":"
       "\"2BFBF7463B008C0298103121874F64B59D2B6172154AA14205DB2CE0BA553B03\",\"transactionOutputIndex\":0},{\"type\":0,"
       "\"transactionId\":\"0000000000000000000000000000000000000000000000000000000000000000\","
-      "\"transactionOutputIndex\":1}],\"outputs\":[{\"type\":0,\"address\":{\"type\":1,\"address\":"
+      "\"transactionOutputIndex\":1}],\"outputs\":[{\"type\":0,\"address\":{\"type\":0,\"address\":"
       "\"AD32258255E7CF927A4833F457F220B7187CF975E82AEEE2E23FCAE5056AB5F4\"},\"amount\":1000},{\"type\":0,\"address\":{"
-      "\"type\":1,\"address\":\"0000000000000000000000000000000000000000000000000000000000000000\"},\"amount\":9999}],"
-      "\"payload\":null},\"unlockBlocks\":[{\"type\":0,\"signature\":{\"type\":1,\"publicKey\":"
+      "\"type\":0,\"address\":\"0000000000000000000000000000000000000000000000000000000000000000\"},\"amount\":9999}],"
+      "\"payload\":null},\"unlockBlocks\":[{\"type\":0,\"signature\":{\"type\":0,\"publicKey\":"
       "\"0000000000000000000000000000000000000000000000000000000000000000\",\"signature\":"
       "\"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
       "000000000000000000\"}},{\"type\":1,\"reference\":0}]},\"nonce\":null}";


### PR DESCRIPTION
# Description of change

fixes #108 
* sign transaction with blake2b hash of essence data.
* the index field uses hex string in the indexation JSON.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
