### PR TITLE
Client - accept bech32 address for get_balance method.

### DIFF
--- a/src/client/api/v1/get_balance.c
+++ b/src/client/api/v1/get_balance.c
@@ -84,9 +84,9 @@ end:
   return ret;
 }
 
-int get_balance(iota_client_conf_t const *conf, char const addr[], res_balance_t *res) {
+int get_balance(iota_client_conf_t const *conf, addr_type_enum addr_type, char const addr[], res_balance_t *res) {
   int ret = -1;
-  char const *const cmd_balance = "/api/v1/addresses/ed25519/";
+
   byte_buf_t *http_res = NULL;
   long http_st = 0;
 
@@ -97,6 +97,16 @@ int get_balance(iota_client_conf_t const *conf, char const addr[], res_balance_t
 
   if (strlen(addr) != IOTA_ADDRESS_HEX_BYTES) {
     printf("[%s:%d]: get_balance failed (invalid addr length)\n", __func__, __LINE__);
+    return -1;
+  }
+
+  char const *cmd_balance = "";
+  if (addr_type == ED25519) {
+    cmd_balance = "/api/v1/addresses/ed25519/";
+  } else if (addr_type == BECH32) {
+    cmd_balance = "/api/v1/addresses/";
+  } else {
+    printf("[%s:%d]: get_balance failed (invalid address)\n", __func__, __LINE__);
     return -1;
   }
 

--- a/src/client/api/v1/get_balance.c
+++ b/src/client/api/v1/get_balance.c
@@ -84,7 +84,7 @@ end:
   return ret;
 }
 
-int get_balance(iota_client_conf_t const *conf, addr_type_enum addr_type, char const addr[], res_balance_t *res) {
+int get_balance(iota_client_conf_t const *conf, bool is_bech32, char const addr[], res_balance_t *res) {
   int ret = -1;
 
   byte_buf_t *http_res = NULL;
@@ -101,13 +101,10 @@ int get_balance(iota_client_conf_t const *conf, addr_type_enum addr_type, char c
   }
 
   char const *cmd_balance = "";
-  if (addr_type == ED25519) {
-    cmd_balance = "/api/v1/addresses/ed25519/";
-  } else if (addr_type == BECH32) {
+  if (is_bech32) {
     cmd_balance = "/api/v1/addresses/";
   } else {
-    printf("[%s:%d]: get_balance failed (invalid address)\n", __func__, __LINE__);
-    return -1;
+    cmd_balance = "/api/v1/addresses/ed25519/";
   }
 
   // compose restful api command

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -62,7 +62,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res);
  * @brief Gets balance from an address
  *
  * @param[in] ctx IOTA Client conf
- * @param[in] addr_type The address type : ED25519/BECH32
+ * @param[in] is_bech32 the address type, true for bech32, false for ed25519
  * @param[in] addr The address
  * @param[out] res A response object of balance info
  * @return int 0 on success

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -12,11 +12,6 @@
 #include "core/types.h"
 
 /**
- * @brief Enum to specify the address type
- */
-typedef enum { ED25519 = 1, BECH32 } addr_type_enum;
-
-/**
  * @brief Stores address string and amount of balance
  *
  */
@@ -72,7 +67,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res);
  * @param[out] res A response object of balance info
  * @return int 0 on success
  */
-int get_balance(iota_client_conf_t const *ctx, addr_type_enum addr_type, char const addr[], res_balance_t *res);
+int get_balance(iota_client_conf_t const *ctx, bool is_bech32, char const addr[], res_balance_t *res);
 
 #ifdef __cplusplus
 }

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -12,6 +12,11 @@
 #include "core/types.h"
 
 /**
+ * @brief Enum to specify the address type
+ */
+typedef enum { ED25519 = 1, BECH32 } addr_type_enum;
+
+/**
  * @brief Stores address string and amount of balance
  *
  */
@@ -66,7 +71,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res);
  * @param[out] res A response object of balance info
  * @return int 0 on success
  */
-int get_balance(iota_client_conf_t const *ctx, char const addr[], res_balance_t *res);
+int get_balance(iota_client_conf_t const *ctx, addr_type_enum addr_type, char const addr[], res_balance_t *res);
 
 #ifdef __cplusplus
 }

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -67,6 +67,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res);
  * @brief Gets balance from an address
  *
  * @param[in] ctx IOTA Client conf
+ * @param[in] addr_type The address type : ED25519/BECH32
  * @param[in] addr The address
  * @param[out] res A response object of balance info
  * @return int 0 on success

--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -312,7 +312,7 @@ int wallet_balance_by_address(iota_wallet_t* w, byte_t const addr[], uint64_t* b
     return -1;
   }
 
-  if (get_balance(&w->endpoint, hex_addr, bal_res) != 0) {
+  if (get_balance(&w->endpoint, ED25519, hex_addr, bal_res) != 0) {
     printf("[%s:%d] Err: get balance API failed\n", __func__, __LINE__);
     res_balance_free(bal_res);
     return -1;

--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -312,7 +312,7 @@ int wallet_balance_by_address(iota_wallet_t* w, byte_t const addr[], uint64_t* b
     return -1;
   }
 
-  if (get_balance(&w->endpoint, ED25519, hex_addr, bal_res) != 0) {
+  if (get_balance(&w->endpoint, false, hex_addr, bal_res) != 0) {
     printf("[%s:%d] Err: get balance API failed\n", __func__, __LINE__);
     res_balance_free(bal_res);
     return -1;

--- a/tests/client/api_v1/test_get_balance.c
+++ b/tests/client/api_v1/test_get_balance.c
@@ -85,7 +85,9 @@ void test_get_balance() {
     char addr_hex_str[IOTA_ADDRESS_HEX_BYTES + 1] = {0};
     TEST_ASSERT(address_bech32_to_hex("iota", addr_hex_bech32, addr_hex_str, sizeof(addr_hex_str)) == 0);
     // Converting hex string to lower case to check equality
-    for (int i = 0; i < IOTA_ADDRESS_HEX_BYTES; i++) addr_hex_str[i] = tolower(addr_hex_str[i]);
+    for (int i = 0; i < IOTA_ADDRESS_HEX_BYTES; i++) {
+      addr_hex_str[i] = tolower(addr_hex_str[i]);
+    }
     // validate address data
     TEST_ASSERT_EQUAL_MEMORY(addr_hex_str, res->u.output_balance->address, IOTA_ADDRESS_HEX_BYTES);
   }

--- a/tests/client/api_v1/test_get_balance.c
+++ b/tests/client/api_v1/test_get_balance.c
@@ -1,6 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,8 +12,11 @@
 #include "client/api/v1/get_balance.h"
 #include "core/utils/byte_buffer.h"
 
-char const* const addr_hex = "7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006";
+char const* const addr_hex_ed25519 = "7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006";
+char const* const addr_hex_bech32 = "iota1qpg2xkj66wwgn8p2ggnp7p582gj8g6p79us5hve2tsudzpsr2ap4skprwjg";
 char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+char const* const addr_hex_invalid_length =
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
 void setUp(void) {}
 
@@ -24,14 +28,30 @@ void test_get_balance() {
   res_balance_t* res = res_balance_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // test null cases
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, NULL, NULL));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, NULL, NULL));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, NULL, res));
+  // test null cases, passing addr_type as 0 as it is an enum
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, 0, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, 0, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, 0, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, 0, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, ED25519, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, BECH32, NULL, res));
 
-  // test invalid address
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, addr_hex_invalid, res));
+  // test invalid address type
+  addr_type_enum addr_type_test = 5;
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, addr_type_test, addr_hex_ed25519, res));
+
+  // test invalid address len
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, ED25519, addr_hex_invalid_length, res));
+
+  // test invalid ED25519 address
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, ED25519, addr_hex_invalid, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
+
+  // test invalid BECH32 address
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, BECH32, addr_hex_invalid, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
@@ -43,17 +63,32 @@ void test_get_balance() {
   res = res_balance_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // test for success
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, addr_hex, res));
+  // test for success - ED25519 address
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, ED25519, addr_hex_ed25519, res));
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   } else {
     // validate address type
     TEST_ASSERT(ADDRESS_VER_ED25519 == res->u.output_balance->address_type);
     // validate address data
-    TEST_ASSERT_EQUAL_MEMORY(addr_hex, res->u.output_balance->address, IOTA_ADDRESS_HEX_BYTES);
+    TEST_ASSERT_EQUAL_MEMORY(addr_hex_ed25519, res->u.output_balance->address, IOTA_ADDRESS_HEX_BYTES);
   }
 
+  // test for success - BECH32 address
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, BECH32, addr_hex_bech32, res));
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  } else {
+    // Note : Bech32 also returns ED25519 address in the response
+    // validate address type
+    TEST_ASSERT(ADDRESS_VER_ED25519 == res->u.output_balance->address_type);
+    char addr_hex_str[IOTA_ADDRESS_HEX_BYTES + 1] = {0};
+    TEST_ASSERT(address_bech32_to_hex("iota", addr_hex_bech32, addr_hex_str, sizeof(addr_hex_str)) == 0);
+    // Converting hex string to lower case to check equality
+    for (int i = 0; i < IOTA_ADDRESS_HEX_BYTES; i++) addr_hex_str[i] = tolower(addr_hex_str[i]);
+    // validate address data
+    TEST_ASSERT_EQUAL_MEMORY(addr_hex_str, res->u.output_balance->address, IOTA_ADDRESS_HEX_BYTES);
+  }
   res_balance_free(res);
 }
 
@@ -72,8 +107,8 @@ void test_deser_balance_info() {
   TEST_ASSERT(res->is_error == false);
   TEST_ASSERT_EQUAL_INT(0, deser_balance_info(json_info_200, res));
   TEST_ASSERT(1 == res->u.output_balance->address_type);
-  TEST_ASSERT_EQUAL_STRING(addr_hex, res->u.output_balance->address);
-  TEST_ASSERT_EQUAL_STRING(res->u.output_balance->address, addr_hex);
+  TEST_ASSERT_EQUAL_STRING(addr_hex_ed25519, res->u.output_balance->address);
+  TEST_ASSERT_EQUAL_STRING(res->u.output_balance->address, addr_hex_ed25519);
   TEST_ASSERT(1338263 == res->u.output_balance->balance);
 
   // clean up

--- a/tests/client/api_v1/test_get_balance.c
+++ b/tests/client/api_v1/test_get_balance.c
@@ -28,30 +28,25 @@ void test_get_balance() {
   res_balance_t* res = res_balance_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // test null cases, passing addr_type as 0 as it is an enum
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, 0, NULL, NULL));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, 0, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, 0, NULL, NULL));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, 0, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, ED25519, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, BECH32, NULL, res));
-
-  // test invalid address type
-  addr_type_enum addr_type_test = 5;
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, addr_type_test, addr_hex_ed25519, res));
+  // test null cases
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, false, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(NULL, false, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, false, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, false, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, true, NULL, res));
 
   // test invalid address len
-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, ED25519, addr_hex_invalid_length, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, false, addr_hex_invalid_length, res));
 
   // test invalid ED25519 address
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, ED25519, addr_hex_invalid, res));
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, false, addr_hex_invalid, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   }
 
   // test invalid BECH32 address
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, BECH32, addr_hex_invalid, res));
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, true, addr_hex_invalid, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
@@ -64,7 +59,7 @@ void test_get_balance() {
   TEST_ASSERT_NOT_NULL(res);
 
   // test for success - ED25519 address
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, ED25519, addr_hex_ed25519, res));
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, false, addr_hex_ed25519, res));
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   } else {
@@ -75,7 +70,7 @@ void test_get_balance() {
   }
 
   // test for success - BECH32 address
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, BECH32, addr_hex_bech32, res));
+  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, true, addr_hex_bech32, res));
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   } else {


### PR DESCRIPTION
# Description of change

fixes #153 
- Added addr_type_enum argument for the method get_balance.
- addr_type_enum can have values ED25519 / BECH32 to specify the type of adress that is passed for balance check.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

-  TEST_ASSERT_EQUAL_INT(-1, get_balance(&conf, BECH32, NULL, res));
-  TEST_ASSERT_EQUAL_INT(0, get_balance(&conf, BECH32, addr_hex_bech32, res));

For testing we need to enable #define TEST_TANGLE_ENABLE 1

## Change checklist

- [ x] My code follows the contribution guidelines for this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have added tests using CTest that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
