### PR TITLE
Client - added dustAllowed and ledgerIndex to get_balance response.

### DIFF
--- a/src/client/api/json_keys.h
+++ b/src/client/api/json_keys.h
@@ -60,5 +60,6 @@ static char const* const JSON_KEY_REF_RATE = "referencedRate";
 static char const* const JSON_KEY_LMT = "latestMilestoneTimestamp";
 static char const* const JSON_KEY_CHILDREN_MSG_IDS = "childrenMessageIds";
 static char const* const JSON_KEY_LEDGER_IDX = "ledgerIndex";
+static char const* const JSON_KEY_DUST_ALLOWED = "dustAllowed";
 
 #endif

--- a/src/client/api/v1/get_balance.c
+++ b/src/client/api/v1/get_balance.c
@@ -77,6 +77,18 @@ int deser_balance_info(char const *const j_str, res_balance_t *res) {
       printf("[%s:%d]: gets %s json balance failed\n", __func__, __LINE__, JSON_KEY_BALANCE);
       goto end;
     }
+
+    // gets dust allowance
+    if ((ret = json_get_boolean(data_obj, JSON_KEY_DUST_ALLOWED, &res->u.output_balance->dust_allowed)) != 0) {
+      printf("[%s:%d]: gets %s failed\n", __func__, __LINE__, JSON_KEY_DUST_ALLOWED);
+      goto end;
+    }
+
+    // gets ledger index
+    if ((ret = json_get_uint64(data_obj, JSON_KEY_LEDGER_IDX, &res->u.output_balance->ledger_idx)) != 0) {
+      printf("[%s:%d]: gets %s failed\n", __func__, __LINE__, JSON_KEY_LEDGER_IDX);
+      goto end;
+    }
   }
 
 end:

--- a/src/client/api/v1/get_balance.c
+++ b/src/client/api/v1/get_balance.c
@@ -61,7 +61,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res) {
   if (data_obj) {
     // gets address type
     if ((ret = json_get_uint8(data_obj, JSON_KEY_ADDR_TYPE, &res->u.output_balance->address_type)) != 0) {
-      printf("[%s:%d]: gets %s json max_results failed\n", __func__, __LINE__, JSON_KEY_ADDR_TYPE);
+      printf("[%s:%d]: gets %s failed\n", __func__, __LINE__, JSON_KEY_ADDR_TYPE);
       goto end;
     }
 
@@ -74,7 +74,7 @@ int deser_balance_info(char const *const j_str, res_balance_t *res) {
 
     // gets balance
     if ((ret = json_get_uint64(data_obj, JSON_KEY_BALANCE, &res->u.output_balance->balance)) != 0) {
-      printf("[%s:%d]: gets %s json balance failed\n", __func__, __LINE__, JSON_KEY_BALANCE);
+      printf("[%s:%d]: gets %s failed\n", __func__, __LINE__, JSON_KEY_BALANCE);
       goto end;
     }
 

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -12,7 +12,7 @@
 #include "core/types.h"
 
 /**
- * @brief Stores address string and amount of balance
+ * @brief Stores address type, amount of balance, address string, dust allowed status and ledger index
  *
  */
 typedef struct {

--- a/src/client/api/v1/get_balance.h
+++ b/src/client/api/v1/get_balance.h
@@ -20,6 +20,8 @@ typedef struct {
   uint64_t balance;                      ///< amount of balance
   char address[IOTA_ADDRESS_HEX_BYTES];  ///< hex address string, ex:
                                          ///< 7ED3D67FC7B619E72E588F51FEF2379E43E6E9A856635843B3F29AA3A3F1F006
+  bool dust_allowed;                     ///< Dust allowance output to the transaction allowed or not
+  uint64_t ledger_idx;                   ///< Ledger Index
 } get_balance_t;
 
 /**

--- a/tests/client/api_v1/test_get_balance.c
+++ b/tests/client/api_v1/test_get_balance.c
@@ -107,6 +107,8 @@ void test_deser_balance_info() {
   TEST_ASSERT_EQUAL_STRING(addr_hex_ed25519, res->u.output_balance->address);
   TEST_ASSERT_EQUAL_STRING(res->u.output_balance->address, addr_hex_ed25519);
   TEST_ASSERT(1338263 == res->u.output_balance->balance);
+  TEST_ASSERT(false == res->u.output_balance->dust_allowed);
+  TEST_ASSERT(1400912 == res->u.output_balance->ledger_idx);
 
   // clean up
   res_balance_free(res);

--- a/tests/client/api_v1/test_get_balance.c
+++ b/tests/client/api_v1/test_get_balance.c
@@ -92,7 +92,7 @@ void test_get_balance() {
 void test_deser_balance_info() {
   char const* json_info_200 =
       "{\"data\":{\"addressType\":1,\"address\":\"7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006\","
-      "\"balance\":1338263}}";
+      "\"balance\":1338263,\"dustAllowed\": false,\"ledgerIndex\": 1400912}}";
   char const* json_info_400 =
       "{\"error\":{\"code\":\"400\",\"message\":\"bad request, error: invalid address: "
       "iot1qxknyfvz2hnulyn6fqelg4ljyzm3sl8ewh5z4mhzuglu4eg9d26lg0h78ec, error: encoding\\/hex: invalid byte: U+0069 "


### PR DESCRIPTION
fixes #159

* Added dust allowed and ledger index variables to get_balance_t structure
* Parsing dustAllowed anb ledgerIndex fields from get_balance response json
* Made necessary changes in test_get_balance.c

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Passed local tests

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
