### PR TITLE
Client - Get output address changes

### DIFF
--- a/src/client/api/v1/get_outputs_from_address.c
+++ b/src/client/api/v1/get_outputs_from_address.c
@@ -131,7 +131,6 @@ int deser_outputs_from_address(char const *const j_str, res_outputs_address_t *r
 
 end:
   cJSON_Delete(json_obj);
-
   return ret;
 }
 

--- a/src/client/api/v1/get_outputs_from_address.c
+++ b/src/client/api/v1/get_outputs_from_address.c
@@ -135,12 +135,11 @@ end:
   return ret;
 }
 
-int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], res_outputs_address_t *res) {
+int get_outputs_from_address(iota_client_conf_t const *conf, bool is_bech32, char const addr[],
+                             res_outputs_address_t *res) {
   int ret = -1;
   long st = 0;
   byte_buf_t *http_res = NULL;
-  char const *const cmd_prefix = "/api/v1/addresses/ed25519/";
-  char const *const cmd_suffix = "/outputs";
 
   if (conf == NULL || addr == NULL || res == NULL) {
     // invalid parameters
@@ -153,18 +152,25 @@ int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], 
     return -1;
   }
 
-  iota_str_t *cmd = iota_str_reserve(strlen(cmd_prefix) + addr_len + strlen(cmd_suffix) + 1);
-  if (cmd == NULL) {
-    printf("[%s:%d]: allocate command buffer failed\n", __func__, __LINE__);
-    return -1;
+  // compose restful api command
+  char cmd_buffer[99] = {0};  // 99 = max size of api path(34) + IOTA_ADDRESS_HEX_BYTES(64) + 1
+  int snprintf_ret;
+
+  if (is_bech32) {
+    snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/v1/addresses/%s/outputs", addr);
+  } else {
+    snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/v1/addresses/ed25519/%s/outputs", addr);
   }
 
-  // composing API command
-  snprintf(cmd->buf, cmd->cap, "%s%s%s", cmd_prefix, addr, cmd_suffix);
-  cmd->len = strlen(cmd->buf);
+  // check if data stored is not more than buffer length
+  if (snprintf_ret > (sizeof(cmd_buffer) - 1)) {
+    printf("[%s:%d]: http cmd buffer overflow\n", __func__, __LINE__);
+    goto done;
+  }
 
   // http client configuration
-  http_client_config_t http_conf = {.host = conf->host, .path = cmd->buf, .use_tls = conf->use_tls, .port = conf->port};
+  http_client_config_t http_conf = {
+      .host = conf->host, .path = cmd_buffer, .use_tls = conf->use_tls, .port = conf->port};
 
   if ((http_res = byte_buf_new()) == NULL) {
     printf("[%s:%d]: OOM\n", __func__, __LINE__);
@@ -180,7 +186,6 @@ int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], 
 
 done:
   // cleanup command
-  iota_str_destroy(cmd);
   byte_buf_free(http_res);
   return ret;
 }

--- a/src/client/api/v1/get_outputs_from_address.c
+++ b/src/client/api/v1/get_outputs_from_address.c
@@ -119,6 +119,11 @@ int deser_outputs_from_address(char const *const j_str, res_outputs_address_t *r
       goto end;
     }
 
+    if ((ret = json_get_uint64(data_obj, JSON_KEY_LEDGER_IDX, &res->u.output_ids->ledger_idx) != 0)) {
+      printf("[%s:%d]: gets %s failed\n", __func__, __LINE__, JSON_KEY_LEDGER_IDX);
+      goto end;
+    }
+
   } else {
     // JSON format mismatched.
     printf("[%s:%d]: parsing JSON object failed\n", __func__, __LINE__);

--- a/src/client/api/v1/get_outputs_from_address.h
+++ b/src/client/api/v1/get_outputs_from_address.h
@@ -20,6 +20,7 @@ typedef struct {
   uint32_t max_results;                      ///< The number of results it can return at most.
   uint32_t count;                            ///< The actual number of found results.
   UT_array *outputs;                         ///< output IDs
+  uint64_t ledger_idx;                       ///< The ledger index at which the output was queried at.
 } get_outputs_address_t;
 
 /**

--- a/src/client/api/v1/get_outputs_from_address.h
+++ b/src/client/api/v1/get_outputs_from_address.h
@@ -83,11 +83,13 @@ int deser_outputs_from_address(char const *const j_str, res_outputs_address_t *r
  * @brief Gets output IDs from a given address
  *
  * @param[in] conf The client endpoint configuration
+ * @param[in] is_bech32 the address type, true for bech32, false for ed25519
  * @param[in] addr An address in hex string format
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], res_outputs_address_t *res);
+int get_outputs_from_address(iota_client_conf_t const *conf, bool is_bech32, char const addr[],
+                             res_outputs_address_t *res);
 
 #ifdef __cplusplus
 }

--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -130,7 +130,7 @@ static transaction_payload_t* wallet_build_transaction(iota_wallet_t* w, bool ch
     return NULL;
   }
 
-  if (get_outputs_from_address(&w->endpoint, tmp_addr, outputs_res) != 0) {
+  if (get_outputs_from_address(&w->endpoint, false, tmp_addr, outputs_res) != 0) {
     printf("[%s:%d] Err: get outputs from address failed\n", __func__, __LINE__);
     goto done;
   }

--- a/tests/client/api_v1/test_outputs_from_address.c
+++ b/tests/client/api_v1/test_outputs_from_address.c
@@ -96,12 +96,24 @@ void test_get_output_ids() {
   // Test invalid address len : bech32 address
   TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, true, addr_hex_invalid_length, res));
 
+  // Re initializing res
+  res_outputs_address_free(res);
+  res = NULL;
+  res = res_outputs_address_new();
+  TEST_ASSERT_NOT_NULL(res);
+
   // Test invalid ED25519 address
   TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, false, addr_hex_invalid, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   }
+
+  // Re initializing res
+  res_outputs_address_free(res);
+  res = NULL;
+  res = res_outputs_address_new();
+  TEST_ASSERT_NOT_NULL(res);
 
   // Test invalid BECH32 address
   TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, true, addr_hex_invalid, res));
@@ -121,6 +133,12 @@ void test_get_output_ids() {
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);
   TEST_ASSERT_EQUAL_STRING(addr1, res->u.output_ids->address);
+
+  // Re initializing res
+  res_outputs_address_free(res);
+  res = NULL;
+  res = res_outputs_address_new();
+  TEST_ASSERT_NOT_NULL(res);
 
   // Tests for bech32 address
   ret = get_outputs_from_address(&ctx, true, addr_bech32, res);

--- a/tests/client/api_v1/test_outputs_from_address.c
+++ b/tests/client/api_v1/test_outputs_from_address.c
@@ -16,7 +16,7 @@ void test_deser_outputs() {
   // empty output ids
   char const* const data_empty =
       "{\"data\":{\"address\":\"017ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f0\",\"maxResults\":1000,"
-      "\"count\":0,\"outputIds\":[]}}";
+      "\"count\":0,\"outputIds\":[],\"ledgerIndex\":837834}}";
 
   res_outputs_address_t* res = res_outputs_address_new();
   TEST_ASSERT_NOT_NULL(res);
@@ -27,6 +27,7 @@ void test_deser_outputs() {
   TEST_ASSERT(res->u.output_ids->max_results == 1000);
   TEST_ASSERT(res->u.output_ids->count == 0);
   TEST_ASSERT(utarray_len(res->u.output_ids->outputs) == 0);
+  TEST_ASSERT(res->u.output_ids->ledger_idx == 837834);
   res_outputs_address_free(res);
   res = NULL;
 
@@ -34,7 +35,7 @@ void test_deser_outputs() {
   char const* const data_1 =
       "{\"data\":{\"address\":\"7ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f006\",\"maxResults\":1000,"
       "\"count\":2,\"outputIds\":[\"1c6943b0487c92fd057d4d22ad844cc37ee27fe6fbe88e5ff0d20b2233f75b9d0005\","
-      "\"ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c0010\"]}}";
+      "\"ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c0010\"],\"ledgerIndex\":837834}}";
   res = res_outputs_address_new();
   TEST_ASSERT_NOT_NULL(res);
   TEST_ASSERT(deser_outputs_from_address(data_1, res) == 0);
@@ -48,6 +49,7 @@ void test_deser_outputs() {
                            res_outputs_address_output_id(res, 0), 69);
   TEST_ASSERT_EQUAL_MEMORY("ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c0010",
                            res_outputs_address_output_id(res, 1), 69);
+  TEST_ASSERT(res->u.output_ids->ledger_idx == 837834);
   res_outputs_address_free(res);
   res = NULL;
 }

--- a/tests/client/api_v1/test_outputs_from_address.c
+++ b/tests/client/api_v1/test_outputs_from_address.c
@@ -76,9 +76,44 @@ void test_deser_outputs_err() {
 void test_get_output_ids() {
   char addr1[] = "017ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f0";
   char addr_bech32[] = "iota1qpg2xkj66wwgn8p2ggnp7p582gj8g6p79us5hve2tsudzpsr2ap4skprwjg";
+  char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const addr_hex_invalid_length =
+      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_address_t* res = res_outputs_address_new();
+  TEST_ASSERT_NOT_NULL(res);
+
+  // Tests for NULL cases
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, false, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, false, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, false, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, true, NULL, res));
+
+  // Test invalid address len : ed25519 address
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, false, addr_hex_invalid_length, res));
+
+  // Test invalid address len : bech32 address
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, true, addr_hex_invalid_length, res));
+
+  // Test invalid ED25519 address
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, false, addr_hex_invalid, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
+
+  // Test invalid BECH32 address
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, true, addr_hex_invalid, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
+
+  // Re initializing res
+  res_outputs_address_free(res);
+  res = NULL;
+  res = res_outputs_address_new();
   TEST_ASSERT_NOT_NULL(res);
 
   // Tests for ed25519 address

--- a/tests/client/api_v1/test_send_message.c
+++ b/tests/client/api_v1/test_send_message.c
@@ -121,7 +121,7 @@ void test_send_core_message_tx() {
   // get outputs
   res_outputs_address_t* res = res_outputs_address_new();
   TEST_ASSERT_NOT_NULL(res);
-  int ret = get_outputs_from_address(&ctx, "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92", res);
+  int ret = get_outputs_from_address(&ctx, false, "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92", res);
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);
   TEST_ASSERT_EQUAL_STRING("6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92",


### PR DESCRIPTION
# Description of change

fixes #161
* Updated response object with ledgerIndex field.
* Support Bech32 address : /api​/v1​/addresses​/{bech32_addr}​/outputs
* Added few NULL and invalid address test cases

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Passes local tests

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
