### PR TITLE
Core - address serializer returns written length

### DIFF
--- a/src/core/address.h
+++ b/src/core/address.h
@@ -107,10 +107,9 @@ size_t address_serialize(address_t *addr, byte_t bytes[], size_t len);
  *
  * @param[in] bytes A buffer holds binary data
  * @param[in] len the length of the buffer
- * @param[out] addr the output address object
- * @return size_t The bytes written is returned, 0 on error
+ * @return address_t* A pointer to the deserialized address, NULL on error
  */
-size_t address_deserialize(byte_t bytes[], size_t len, address_t *addr);
+address_t *address_deserialize(byte_t bytes[], size_t len);
 
 /**
  * @brief Create an address object from the given bech32 string
@@ -157,6 +156,13 @@ address_t *address_clone(address_t const *const addr);
  * @param[in] addr An address object
  */
 void address_print(address_t const *const addr);
+
+/**
+ * @brief Free an address object
+ *
+ * @param[in] addr An address object
+ */
+void free_address(address_t *addr);
 
 #ifdef __cplusplus
 }

--- a/src/core/address.h
+++ b/src/core/address.h
@@ -98,9 +98,9 @@ uint8_t address_serialized_len(address_t *addr);
  * @param[in] addr An address object
  * @param[out] bytes A buffer hold serialized data
  * @param[in] len The length of the buffer
- * @return int o on success
+ * @return size_t The bytes written is returned, 0 on error
  */
-int address_serialize(address_t *addr, byte_t bytes[], size_t len);
+size_t address_serialize(address_t *addr, byte_t bytes[], size_t len);
 
 /**
  * @brief Deserialize a bniary data to an address object
@@ -108,9 +108,9 @@ int address_serialize(address_t *addr, byte_t bytes[], size_t len);
  * @param[in] bytes A buffer holds binary data
  * @param[in] len the length of the buffer
  * @param[out] addr the output address object
- * @return int 0 on success
+ * @return size_t The bytes written is returned, 0 on error
  */
-int address_deserialize(byte_t bytes[], size_t len, address_t *addr);
+size_t address_deserialize(byte_t bytes[], size_t len, address_t *addr);
 
 /**
  * @brief Create an address object from the given bech32 string

--- a/tests/core/test_address.c
+++ b/tests/core/test_address.c
@@ -35,9 +35,10 @@ void test_ed25519_gen() {
 
   TEST_ASSERT(ed25519_address_from_path(seed, sizeof(seed), "m/44'/4218'/0'/0'/0'", &ed25519_addr) == 0);
   // dump_hex(ed25519_addr.address, 32);
-  TEST_ASSERT(address_serialize(&ed25519_addr, ed25519_serialized, sizeof(ed25519_serialized)) == 0);
-  // dump_hex(ed25519_serialized, 33);
-  TEST_ASSERT_EQUAL_MEMORY(exp_addr, ed25519_serialized, address_serialized_len(&ed25519_addr));
+  size_t ser_len = address_serialize(&ed25519_addr, ed25519_serialized, sizeof(ed25519_serialized));
+  TEST_ASSERT(ser_len == address_serialized_len(&ed25519_addr));
+  // dump_hex(ed25519_serialized, ser_len);
+  TEST_ASSERT_EQUAL_MEMORY(exp_addr, ed25519_serialized, ser_len);
 
   // convert binary address to bech32 with iota HRP
   char const *const exp_iota_bech32 = "iota1qpg4tqh7vj9s7y9zk2smj8t4qgvse9um42l7apdkhw6syp5ju4w3v79tf3l";
@@ -91,29 +92,47 @@ void test_serializer() {
   // random address
   iota_crypto_randombytes(addr_bin, ADDRESS_MAX_BYTES);
 
+  // deserialized and serialized length
+  size_t deser_len = 0, ser_len = 0;
   // ed25519 serializer
   addr_bin[0] = ADDRESS_TYPE_ED25519;
-  TEST_ASSERT(address_deserialize(addr_bin, ADDRESS_ED25519_BYTES + 1, &addr_obj) == 0);
+  // deserialize with insufficient buffer size
+  TEST_ASSERT(address_deserialize(addr_bin, 1, &addr_obj) == 0);
+  // convert a binary to an address object
+  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
+  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
   TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_ED25519);
   TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_ED25519_BYTES);
-  TEST_ASSERT(address_serialize(&addr_obj, addr_ser, address_serialized_len(&addr_obj)) == 0);
-  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, address_serialized_len(&addr_obj));
+  // serialize with insufficient buffer size
+  TEST_ASSERT(address_serialize(&addr_obj, addr_ser, 1) == 0);
+  // convert an address object to a binary data
+  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
+  TEST_ASSERT(ser_len == deser_len);
+  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
 
   // alias serializer
   addr_bin[0] = ADDRESS_TYPE_ALIAS;
-  TEST_ASSERT(address_deserialize(addr_bin, ADDRESS_ALIAS_BYTES + 1, &addr_obj) == 0);
+  // convert a binary to an address object
+  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
+  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
   TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_ALIAS);
   TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_ALIAS_BYTES);
-  TEST_ASSERT(address_serialize(&addr_obj, addr_ser, address_serialized_len(&addr_obj)) == 0);
-  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, address_serialized_len(&addr_obj));
+  // convert an address object to a binary data
+  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
+  TEST_ASSERT(ser_len == deser_len);
+  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
 
   // nft serializer
   addr_bin[0] = ADDRESS_TYPE_NFT;
-  TEST_ASSERT(address_deserialize(addr_bin, ADDRESS_NFT_BYTES + 1, &addr_obj) == 0);
+  // convert a binary to an address object
+  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
+  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
   TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_NFT);
   TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_NFT_BYTES);
-  TEST_ASSERT(address_serialize(&addr_obj, addr_ser, address_serialized_len(&addr_obj)) == 0);
-  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, address_serialized_len(&addr_obj));
+  // convert an address object to a binary data
+  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
+  TEST_ASSERT(ser_len == deser_len);
+  TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
 }
 
 int main() {

--- a/tests/core/test_address.c
+++ b/tests/core/test_address.c
@@ -41,7 +41,7 @@ void test_ed25519_gen() {
   TEST_ASSERT_EQUAL_MEMORY(exp_addr, ed25519_serialized, ser_len);
 
   // convert binary address to bech32 with iota HRP
-  char const *const exp_iota_bech32 = "iota1qpg4tqh7vj9s7y9zk2smj8t4qgvse9um42l7apdkhw6syp5ju4w3v79tf3l";
+  char const* const exp_iota_bech32 = "iota1qpg4tqh7vj9s7y9zk2smj8t4qgvse9um42l7apdkhw6syp5ju4w3v79tf3l";
   TEST_ASSERT(address_to_bech32(&ed25519_addr, "iota", bech32_str, sizeof(bech32_str)) == 0);
   TEST_ASSERT_EQUAL_STRING(exp_iota_bech32, bech32_str);
   // printf("bech32 [iota]: %s\n", bech32_str);
@@ -85,54 +85,71 @@ void test_nft_gen() {
 }
 
 void test_serializer() {
-  byte_t addr_bin[ADDRESS_MAX_BYTES + 1] = {};
-  byte_t addr_ser[ADDRESS_MAX_BYTES + 1] = {};
+  byte_t addr_bin[ADDRESS_SERIALIZED_MAX_BYTES] = {};  // random data
+  byte_t addr_ser[ADDRESS_SERIALIZED_MAX_BYTES] = {};  // serialized address
+  address_t* addr_obj = NULL;                          // deserialized address
+  size_t ser_len = 0;                                  // bytes written to serialized buffer
 
-  address_t addr_obj = {};
   // random address
-  iota_crypto_randombytes(addr_bin, ADDRESS_MAX_BYTES);
+  iota_crypto_randombytes(addr_bin, ADDRESS_SERIALIZED_MAX_BYTES);
 
-  // deserialized and serialized length
-  size_t deser_len = 0, ser_len = 0;
   // ed25519 serializer
   addr_bin[0] = ADDRESS_TYPE_ED25519;
   // deserialize with insufficient buffer size
-  TEST_ASSERT(address_deserialize(addr_bin, 1, &addr_obj) == 0);
+  TEST_ASSERT_NULL(address_deserialize(addr_bin, 1));
   // convert a binary to an address object
-  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
-  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
-  TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_ED25519);
-  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_ED25519_BYTES);
+  addr_obj = address_deserialize(addr_bin, sizeof(addr_bin));
+  TEST_ASSERT_NOT_NULL(addr_obj);
+  TEST_ASSERT(addr_obj->type == ADDRESS_TYPE_ED25519);
+  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj->address, ADDRESS_ED25519_BYTES);
   // serialize with insufficient buffer size
-  TEST_ASSERT(address_serialize(&addr_obj, addr_ser, 1) == 0);
+  TEST_ASSERT(address_serialize(addr_obj, addr_ser, 1) == 0);
   // convert an address object to a binary data
-  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
-  TEST_ASSERT(ser_len == deser_len);
+  ser_len = address_serialize(addr_obj, addr_ser, sizeof(addr_ser));
   TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
+  free_address(addr_obj);
 
   // alias serializer
   addr_bin[0] = ADDRESS_TYPE_ALIAS;
   // convert a binary to an address object
-  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
-  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
-  TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_ALIAS);
-  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_ALIAS_BYTES);
+  addr_obj = address_deserialize(addr_bin, sizeof(addr_bin));
+  TEST_ASSERT_NOT_NULL(addr_obj);
+  TEST_ASSERT(addr_obj->type == ADDRESS_TYPE_ALIAS);
+  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj->address, ADDRESS_ALIAS_BYTES);
   // convert an address object to a binary data
-  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
-  TEST_ASSERT(ser_len == deser_len);
+  ser_len = address_serialize(addr_obj, addr_ser, sizeof(addr_ser));
   TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
+  free_address(addr_obj);
 
   // nft serializer
   addr_bin[0] = ADDRESS_TYPE_NFT;
   // convert a binary to an address object
-  deser_len = address_deserialize(addr_bin, sizeof(addr_bin), &addr_obj);
-  TEST_ASSERT(deser_len == address_serialized_len(&addr_obj));
-  TEST_ASSERT(addr_obj.type == ADDRESS_TYPE_NFT);
-  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj.address, ADDRESS_NFT_BYTES);
+  addr_obj = address_deserialize(addr_bin, sizeof(addr_bin));
+  TEST_ASSERT_NOT_NULL(addr_obj);
+  TEST_ASSERT(addr_obj->type == ADDRESS_TYPE_NFT);
+  TEST_ASSERT_EQUAL_MEMORY(addr_bin + 1, addr_obj->address, ADDRESS_NFT_BYTES);
   // convert an address object to a binary data
-  ser_len = address_serialize(&addr_obj, addr_ser, sizeof(addr_ser));
-  TEST_ASSERT(ser_len == deser_len);
+  ser_len = address_serialize(addr_obj, addr_ser, sizeof(addr_ser));
   TEST_ASSERT_EQUAL_MEMORY(addr_ser, addr_bin, ser_len);
+  free_address(addr_obj);
+}
+
+void test_clone_equal() {
+  byte_t addr_bin[ADDRESS_SERIALIZED_MAX_BYTES] = {};  // random data
+  iota_crypto_randombytes(addr_bin, ADDRESS_SERIALIZED_MAX_BYTES);
+  addr_bin[0] = ADDRESS_TYPE_ED25519;
+
+  address_t* addr1 = address_deserialize(addr_bin, sizeof(addr_bin));
+  TEST_ASSERT_NOT_NULL(addr1);
+  address_t* addr2 = address_clone(addr1);
+  TEST_ASSERT_NOT_NULL(addr2);
+  TEST_ASSERT(address_equal(addr1, addr2) == true);
+
+  iota_crypto_randombytes(addr2->address, ADDRESS_ED25519_BYTES);
+  TEST_ASSERT(address_equal(addr1, addr2) == false);
+
+  free_address(addr1);
+  free_address(addr2);
 }
 
 int main() {
@@ -142,6 +159,7 @@ int main() {
   RUN_TEST(test_alias_gen);
   RUN_TEST(test_nft_gen);
   RUN_TEST(test_serializer);
+  RUN_TEST(test_clone_equal);
 
   return UNITY_END();
 }


### PR DESCRIPTION
# Description of change

`address_deserialize` and `address_serialize` return the written length of the given buffer.

