### PR TITLE
Core - added feature block syntactic checks

### DIFF
--- a/src/core/models/outputs/feat_blocks.c
+++ b/src/core/models/outputs/feat_blocks.c
@@ -406,6 +406,18 @@ uint8_t feat_blk_list_len(feat_blk_list_t* list) {
   return len;
 }
 
+feat_block_t* feat_blk_list_get_type(feat_blk_list_t* list, feat_block_e type) {
+  feat_blk_list_t* elm;
+  if (list) {
+    LL_FOREACH(list, elm) {
+      if (elm->blk->type == type) {
+        return elm->blk;
+      }
+    }
+  }
+  return NULL;
+}
+
 feat_block_t* feat_blk_list_get(feat_blk_list_t* list, uint8_t index) {
   uint8_t count = 0;
   feat_blk_list_t* elm;
@@ -428,7 +440,13 @@ int feat_blk_list_add_sender(feat_blk_list_t** list, address_t const* const addr
 
   // check if list length is reached the limitation
   if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
-    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    printf("[%s:%d]list count must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    return -1;
+  }
+
+  // at most one of the sender block
+  if (feat_blk_list_get_type(*list, FEAT_SENDER_BLOCK)) {
+    printf("[%s:%d] sender block has exist in the list\n", __func__, __LINE__);
     return -1;
   }
 
@@ -454,7 +472,13 @@ int feat_blk_list_add_issuer(feat_blk_list_t** list, address_t const* const addr
 
   // check if list length is reached the limitation
   if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
-    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    printf("[%s:%d]list count must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    return -1;
+  }
+
+  // at most one of the issuer block
+  if (feat_blk_list_get_type(*list, FEAT_ISSUER_BLOCK)) {
+    printf("[%s:%d] issuer block has exist in the list\n", __func__, __LINE__);
     return -1;
   }
 
@@ -480,7 +504,13 @@ int feat_blk_list_add_metadata(feat_blk_list_t** list, byte_t const data[], uint
 
   // check if list length is reached the limitation
   if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
-    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    printf("[%s:%d]list count must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    return -1;
+  }
+
+  // at most one of the metadata block
+  if (feat_blk_list_get_type(*list, FEAT_METADATA_BLOCK)) {
+    printf("[%s:%d] metadata block has exist in the list\n", __func__, __LINE__);
     return -1;
   }
 
@@ -506,7 +536,13 @@ int feat_blk_list_add_tag(feat_blk_list_t** list, byte_t const tag[], uint8_t ta
 
   // check if list length is reached the limitation
   if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
-    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    printf("[%s:%d]list count must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
+    return -1;
+  }
+
+  // at most one of the metadata block
+  if (feat_blk_list_get_type(*list, FEAT_TAG_BLOCK)) {
+    printf("[%s:%d] tag block has exist in the list\n", __func__, __LINE__);
     return -1;
   }
 

--- a/src/core/models/outputs/feat_blocks.c
+++ b/src/core/models/outputs/feat_blocks.c
@@ -8,9 +8,14 @@
 #include "core/models/outputs/feat_blocks.h"
 #include "utlist.h"
 
-static feat_metadata_blk_t* new_feat_metadata(byte_t const data[], uint32_t data_len) {
+static feat_metadata_blk_t* feat_metadata_new(byte_t const data[], uint32_t data_len) {
   if (!data || data_len == 0) {
     printf("[%s:%d] invalid parameter\n", __func__, __LINE__);
+    return NULL;
+  }
+
+  if (data_len > MAX_METADATA_LENGTH_BYTES) {
+    printf("[%s:%d] data must smaller than %d\n", __func__, __LINE__, MAX_METADATA_LENGTH_BYTES);
     return NULL;
   }
 
@@ -28,7 +33,58 @@ static feat_metadata_blk_t* new_feat_metadata(byte_t const data[], uint32_t data
   return meta;
 }
 
-static void free_feat_metadata(feat_metadata_blk_t* meta) {
+static size_t feat_metadata_serialized_len(feat_metadata_blk_t* meta) {
+  if (meta) {
+    return sizeof(meta->data_len) + meta->data_len;
+  }
+  return 0;
+}
+
+static size_t feat_metadata_serialize(feat_metadata_blk_t* meta, byte_t buf[], size_t buf_len) {
+  size_t offset = 0;
+  if (meta) {
+    if (buf_len >= feat_metadata_serialized_len(meta)) {
+      memcpy(buf, &meta->data_len, sizeof(meta->data_len));
+      offset += sizeof(meta->data_len);
+      memcpy(buf + offset, meta->data, meta->data_len);
+      offset += meta->data_len;
+    } else {
+      printf("[%s:%d] insufficent buffer size\n", __func__, __LINE__);
+    }
+  }
+  return offset;
+}
+
+static feat_metadata_blk_t* feat_metadata_deserialize(byte_t const buf[], size_t buf_len) {
+  // allocate metadata object
+  feat_metadata_blk_t* meta = malloc(sizeof(feat_metadata_blk_t));
+
+  // meta/buf are not null and buf_len can contain one byte
+  if (meta && buf && (buf_len >= sizeof(meta->data_len) + sizeof(byte_t))) {
+    // fetch the length of metadata
+    size_t offset = sizeof(meta->data_len);
+    memcpy(&meta->data_len, buf, sizeof(meta->data_len));
+
+    // check if buffer length smaller than metadata length
+    if ((buf_len - offset) >= meta->data_len) {
+      // allocate metadata memory
+      meta->data = malloc(meta->data_len);
+      if (meta->data) {
+        // copy buffer data to metadata
+        memcpy(meta->data, buf + offset, meta->data_len);
+        return meta;
+      } else {
+        printf("[%s:%d] buffer length doesn't match with data length\n", __func__, __LINE__);
+      }
+    } else {
+      printf("[%s:%d] buffer length doesn't match with data length\n", __func__, __LINE__);
+    }
+  }
+  free(meta);
+  return NULL;
+}
+
+static void feat_metadata_free(feat_metadata_blk_t* meta) {
   if (meta) {
     if (meta->data) {
       free(meta->data);
@@ -37,9 +93,14 @@ static void free_feat_metadata(feat_metadata_blk_t* meta) {
   }
 }
 
-static feat_tag_blk_t* new_feat_tag(byte_t const tag[], uint8_t tag_len) {
+static feat_tag_blk_t* feat_tag_new(byte_t const tag[], uint8_t tag_len) {
   if (!tag || tag_len == 0) {
     printf("[%s:%d] invalid parameter\n", __func__, __LINE__);
+    return NULL;
+  }
+
+  if (tag_len > MAX_INDEX_TAG_BYTES) {
+    printf("[%s:%d] tag length must smaller than %d\n", __func__, __LINE__, MAX_INDEX_TAG_BYTES);
     return NULL;
   }
 
@@ -50,6 +111,56 @@ static feat_tag_blk_t* new_feat_tag(byte_t const tag[], uint8_t tag_len) {
     return idx;
   }
   return idx;
+}
+
+static size_t feat_tag_serialize_len(feat_tag_blk_t* tag) {
+  if (tag) {
+    return sizeof(tag->tag_len) + tag->tag_len;
+  }
+  return 0;
+}
+
+static size_t feat_tag_serialize(feat_tag_blk_t* tag, byte_t buf[], size_t buf_len) {
+  size_t offset = 0;
+  if (tag) {
+    if (buf_len >= feat_tag_serialize_len(tag)) {
+      memcpy(buf, &tag->tag_len, sizeof(tag->tag_len));
+      offset += sizeof(tag->tag_len);
+      memcpy(buf + offset, tag->tag, tag->tag_len);
+      offset += tag->tag_len;
+    } else {
+      printf("[%s:%d] insufficent buffer size\n", __func__, __LINE__);
+    }
+  }
+  return offset;
+}
+
+static feat_tag_blk_t* feat_tag_deserialize(byte_t const buf[], size_t buf_len) {
+  // allocate tag object
+  feat_tag_blk_t* tag = malloc(sizeof(feat_tag_blk_t));
+
+  // tag/buf are not null and buf_len can contain more than one byte
+  if (tag && buf && (buf_len >= sizeof(tag->tag_len) + sizeof(byte_t))) {
+    // fetch the length of tag
+    size_t offset = sizeof(tag->tag_len);
+    memcpy(&tag->tag_len, buf, sizeof(tag->tag_len));
+
+    // check if buffer length smaller than tag length and tag length smaller than MAX_INDEX_TAG_BYTES
+    if (((buf_len - offset) >= tag->tag_len) && (tag->tag_len <= MAX_INDEX_TAG_BYTES)) {
+      memcpy(tag->tag, buf + offset, tag->tag_len);
+      return tag;
+    } else {
+      printf("[%s:%d] buffer length doesn't match with tag length\n", __func__, __LINE__);
+    }
+  }
+  free(tag);
+  return NULL;
+}
+
+static void feat_tag_free(feat_tag_blk_t* tag) {
+  if (tag) {
+    free(tag);
+  }
 }
 
 // feature blocks must be sorted in ascending order based on feature block type
@@ -103,7 +214,7 @@ feat_block_t* feat_blk_metadata_new(byte_t const data[], uint32_t data_len) {
 
   feat_block_t* blk = malloc(sizeof(feat_block_t));
   if (blk) {
-    blk->block = new_feat_metadata(data, data_len);
+    blk->block = feat_metadata_new(data, data_len);
     if (!blk->block) {
       free(blk);
       return NULL;
@@ -115,21 +226,19 @@ feat_block_t* feat_blk_metadata_new(byte_t const data[], uint32_t data_len) {
 }
 
 feat_block_t* feat_blk_tag_new(byte_t const tag[], uint8_t tag_len) {
-  if (!tag) {
+  if (!tag || !tag_len || (tag_len > MAX_INDEX_TAG_BYTES)) {
     printf("[%s:%d] invalid parameter\n", __func__, __LINE__);
     return NULL;
   }
 
   feat_block_t* blk = malloc(sizeof(feat_block_t));
   if (blk) {
-    blk->block = malloc(sizeof(feat_tag_blk_t));
+    blk->block = feat_tag_new(tag, tag_len);
     if (!blk->block) {
       free(blk);
       return NULL;
     }
     blk->type = FEAT_TAG_BLOCK;
-    ((feat_tag_blk_t*)blk->block)->tag_len = tag_len;
-    memcpy(((feat_tag_blk_t*)blk->block)->tag, tag, tag_len);
     return blk;
   }
   return blk;
@@ -147,11 +256,11 @@ size_t feat_blk_serialize_len(feat_block_t const* const blk) {
       // block type + address
       return sizeof(uint8_t) + address_serialized_len((address_t*)blk->block);
     case FEAT_METADATA_BLOCK:
-      // block type + data len + data
-      return sizeof(uint8_t) + sizeof(uint32_t) + ((feat_metadata_blk_t*)blk->block)->data_len;
+      // block type + metadata block
+      return sizeof(uint8_t) + feat_metadata_serialized_len((feat_metadata_blk_t*)blk->block);
     case FEAT_TAG_BLOCK:
-      // block type + tag len + tag
-      return sizeof(uint8_t) + sizeof(uint8_t) + ((feat_tag_blk_t*)blk->block)->tag_len;
+      // block type + tag block
+      return sizeof(uint8_t) + feat_tag_serialize_len((feat_tag_blk_t*)blk->block);
     default:
       printf("[%s:%d] unknown feature block type\n", __func__, __LINE__);
       return 0;
@@ -170,33 +279,29 @@ size_t feat_blk_serialize(feat_block_t* blk, byte_t buf[], size_t buf_len) {
     return 0;
   }
 
+  size_t offset = 0;
   // fillin block type
   memcpy(buf, &blk->type, sizeof(uint8_t));
+  offset += sizeof(uint8_t);
 
   switch (blk->type) {
     case FEAT_SENDER_BLOCK:
     case FEAT_ISSUER_BLOCK:
       // serialize address object
-      if (address_serialize((address_t*)blk->block, buf + 1, buf_len - 1) != 0) {
-        printf("[%s:%d] address serialization failed\n", __func__, __LINE__);
-      }
+      offset += address_serialize((address_t*)blk->block, buf + offset, buf_len - offset);
       break;
     case FEAT_METADATA_BLOCK:
-      // serialize data_len and data
-      memcpy(buf + sizeof(uint8_t), &((feat_metadata_blk_t*)blk->block)->data_len, sizeof(uint32_t));
-      memcpy(buf + sizeof(uint8_t) + sizeof(uint32_t), ((feat_metadata_blk_t*)blk->block)->data,
-             ((feat_metadata_blk_t*)blk->block)->data_len);
+      // serialize metadata
+      offset += feat_metadata_serialize((feat_metadata_blk_t*)blk->block, buf + offset, buf_len - offset);
       break;
     case FEAT_TAG_BLOCK:
-      // serialize tag_len and tag
-      memcpy(buf + sizeof(uint8_t), &((feat_tag_blk_t*)blk->block)->tag_len, sizeof(uint8_t));
-      memcpy(buf + sizeof(uint8_t) + sizeof(uint8_t), ((feat_tag_blk_t*)blk->block)->tag,
-             ((feat_tag_blk_t*)blk->block)->tag_len);
+      // serialize tag block
+      offset += feat_tag_serialize((feat_tag_blk_t*)blk->block, buf + offset, buf_len - offset);
       break;
     default:
       break;
   }
-  return expected_bytes;
+  return offset;
 }
 
 feat_block_t* feat_blk_deserialize(byte_t buf[], size_t buf_len) {
@@ -211,69 +316,30 @@ feat_block_t* feat_blk_deserialize(byte_t buf[], size_t buf_len) {
     return NULL;
   }
 
+  size_t offset = sizeof(uint8_t);
   // fetch block type
   blk->type = buf[0];
   blk->block = NULL;
 
   switch (blk->type) {
     case FEAT_SENDER_BLOCK:
-    case FEAT_ISSUER_BLOCK: {
-      // serialize address
-      address_t* addr = malloc(sizeof(address_t));
-      if (!addr) {
-        feat_blk_free(blk);
-        printf("[%s:%d] new address failed\n", __func__, __LINE__);
-        return NULL;
-      }
-      // fetch address type
-      addr->type = buf[1];
-      // point address object to the feature block member
-      blk->block = addr;
-      // validating data length for address object
-      if (buf_len < (sizeof(uint8_t) + address_serialized_len(addr))) {
-        printf("[%s:%d] invalid data length\n", __func__, __LINE__);
-        feat_blk_free(blk);
-        return NULL;
-      }
-      memcpy(addr->address, buf + sizeof(uint8_t) * 2, address_len(addr));
-    } break;
-
-    case FEAT_METADATA_BLOCK: {
-      uint32_t offset = sizeof(uint8_t) + sizeof(uint32_t);
-      if (buf_len <= offset) {
-        printf("[%s:%d] buffer size is insufficient\n", __func__, __LINE__);
-        feat_blk_free(blk);
-        return NULL;
-      }
-      // get data length
-      uint32_t data_len = 0;
-      memcpy(&data_len, buf + sizeof(uint8_t), sizeof(uint32_t));
-      blk->block = new_feat_metadata(buf + offset, data_len);
-      if (!blk->block) {
-        printf("[%s:%d] deserialize metadata failed\n", __func__, __LINE__);
-        feat_blk_free(blk);
-        return NULL;
-      }
-    } break;
-    case FEAT_TAG_BLOCK: {
-      uint32_t offset = sizeof(uint8_t) + sizeof(uint8_t);
-      if (buf_len <= offset) {
-        printf("[%s:%d] buffer size is insufficient\n", __func__, __LINE__);
-        feat_blk_free(blk);
-        return NULL;
-      }
-      // get tag length
-      uint32_t tag_len = 0;
-      memcpy(&tag_len, buf + sizeof(uint8_t), sizeof(uint8_t));
-      blk->block = new_feat_tag(buf + offset, tag_len);
-      if (!blk->block) {
-        printf("[%s:%d] deserialize metadata failed\n", __func__, __LINE__);
-        feat_blk_free(blk);
-        return NULL;
-      }
-    } break;
+    case FEAT_ISSUER_BLOCK:
+      blk->block = address_deserialize(buf + offset, buf_len - offset);
+      break;
+    case FEAT_METADATA_BLOCK:
+      blk->block = feat_metadata_deserialize(buf + offset, buf_len - offset);
+      break;
+    case FEAT_TAG_BLOCK:
+      blk->block = feat_tag_deserialize(buf + offset, buf_len - offset);
+      break;
     default:
       break;
+  }
+
+  if (!blk->block) {
+    printf("[%s:%d] block deserialization failed\n", __func__, __LINE__);
+    feat_blk_free(blk);
+    return NULL;
   }
   return blk;
 }
@@ -281,10 +347,19 @@ feat_block_t* feat_blk_deserialize(byte_t buf[], size_t buf_len) {
 void feat_blk_free(feat_block_t* blk) {
   if (blk) {
     if (blk->block) {
-      if (blk->type == FEAT_METADATA_BLOCK) {
-        free_feat_metadata((feat_metadata_blk_t*)blk->block);
-      } else {
-        free(blk->block);
+      switch (blk->type) {
+        case FEAT_ISSUER_BLOCK:
+        case FEAT_SENDER_BLOCK:
+          free_address((address_t*)blk->block);
+          break;
+        case FEAT_METADATA_BLOCK:
+          feat_metadata_free((feat_metadata_blk_t*)blk->block);
+          break;
+        case FEAT_TAG_BLOCK:
+          feat_tag_free((feat_tag_blk_t*)blk->block);
+          break;
+        default:
+          break;
       }
     }
     free(blk);
@@ -347,11 +422,13 @@ feat_block_t* feat_blk_list_get(feat_blk_list_t* list, uint8_t index) {
 
 int feat_blk_list_add_sender(feat_blk_list_t** list, address_t const* const addr) {
   if (!addr) {
+    printf("[%s:%d] invalid parameters\n", __func__, __LINE__);
     return -1;
   }
 
   // check if list length is reached the limitation
-  if (feat_blk_list_len(*list) >= UINT8_MAX - 1) {
+  if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
+    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
     return -1;
   }
 
@@ -371,11 +448,13 @@ int feat_blk_list_add_sender(feat_blk_list_t** list, address_t const* const addr
 
 int feat_blk_list_add_issuer(feat_blk_list_t** list, address_t const* const addr) {
   if (!addr) {
+    printf("[%s:%d] invalid parameters\n", __func__, __LINE__);
     return -1;
   }
 
   // check if list length is reached the limitation
-  if (feat_blk_list_len(*list) >= UINT8_MAX - 1) {
+  if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
+    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
     return -1;
   }
 
@@ -394,8 +473,14 @@ int feat_blk_list_add_issuer(feat_blk_list_t** list, address_t const* const addr
 }
 
 int feat_blk_list_add_metadata(feat_blk_list_t** list, byte_t const data[], uint32_t data_len) {
+  if (!data || !data_len) {
+    printf("[%s:%d] invalid parameters\n", __func__, __LINE__);
+    return -1;
+  }
+
   // check if list length is reached the limitation
-  if (feat_blk_list_len(*list) >= UINT8_MAX - 1) {
+  if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
+    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
     return -1;
   }
 
@@ -414,8 +499,14 @@ int feat_blk_list_add_metadata(feat_blk_list_t** list, byte_t const data[], uint
 }
 
 int feat_blk_list_add_tag(feat_blk_list_t** list, byte_t const tag[], uint8_t tag_len) {
+  if (!tag || !tag_len) {
+    printf("[%s:%d] invalid parameters\n", __func__, __LINE__);
+    return -1;
+  }
+
   // check if list length is reached the limitation
-  if (feat_blk_list_len(*list) >= UINT8_MAX - 1) {
+  if (feat_blk_list_len(*list) >= MAX_FEATURE_BLOCK_COUNT) {
+    printf("[%s:%d]list const must smaller than %d\n", __func__, __LINE__, MAX_FEATURE_BLOCK_COUNT);
     return -1;
   }
 
@@ -433,14 +524,15 @@ int feat_blk_list_add_tag(feat_blk_list_t** list, byte_t const tag[], uint8_t ta
 }
 
 size_t feat_blk_list_serialize_len(feat_blk_list_t* list) {
-  feat_blk_list_t* elm;
-  // feature blocks layout: Block Count + Blocks
-  // uint8_t is the serialized size of block count
-  size_t len = sizeof(uint8_t);
   if (list) {
+    feat_blk_list_t* elm;
+    // feature blocks layout: Block Count + Blocks
+    // uint8_t is the serialized size of block count
+    size_t len = sizeof(uint8_t);
     LL_FOREACH(list, elm) { len += feat_blk_serialize_len(elm->blk); }
+    return len;
   }
-  return len;
+  return 0;
 }
 
 void feat_blk_list_sort(feat_blk_list_t** list) {
@@ -449,21 +541,23 @@ void feat_blk_list_sort(feat_blk_list_t** list) {
 }
 
 size_t feat_blk_list_serialize(feat_blk_list_t** list, byte_t buf[], size_t buf_len) {
-  if (list || *list) {
+  if ((list || *list) && buf) {
     // serialized len = block count + blocks
     size_t expected_bytes = feat_blk_list_serialize_len(*list);
     if (buf_len < expected_bytes) {
+      printf("[%s:%d] insufficent buffer size\n", __func__, __LINE__);
       return 0;
     }
 
     size_t offset = sizeof(uint8_t);
     feat_blk_list_t* elm;
-    int ret = 0;
-    // block count
+    // fetch block count
     buf[0] = feat_blk_list_len(*list);
+
     // sort by block types
     feat_blk_list_sort(list);
-    // feature blocks
+
+    // serialize feature blocks
     LL_FOREACH(*list, elm) { offset += feat_blk_serialize(elm->blk, buf + offset, buf_len - offset); }
     // check the length of the serialized data
     if (offset != expected_bytes) {
@@ -477,6 +571,7 @@ size_t feat_blk_list_serialize(feat_blk_list_t** list, byte_t buf[], size_t buf_
 
 feat_blk_list_t* feat_blk_list_deserialize(byte_t buf[], size_t buf_len) {
   if (!buf || buf_len <= 1) {
+    printf("[%s:%d] invalid parameters\n", __func__, __LINE__);
     return NULL;
   }
 

--- a/src/core/models/outputs/feat_blocks.h
+++ b/src/core/models/outputs/feat_blocks.h
@@ -18,9 +18,9 @@
 // Maximum possible length in bytes of a Tag
 #define MAX_INDEX_TAG_BYTES 64
 // Maximun possible length in bytes of Metadata
-#define MAX_METADATA_LGN_BYTES 1024
+#define MAX_METADATA_LENGTH_BYTES 1024
 // Maximun Feature Blocks in a list
-#define MAX_FEATURE_BLOCK_COUNT 3
+#define MAX_FEATURE_BLOCK_COUNT 4
 
 /**
  * @brief all feature block types
@@ -51,7 +51,7 @@ typedef struct {
  *
  */
 typedef struct {
-  uint32_t data_len;  ///< the data length of the Metadata, max length is TBD.
+  uint32_t data_len;  ///< the data length of the Metadata
   byte_t* data;       ///< the data of Metadata.
 } feat_metadata_blk_t;
 

--- a/src/core/models/outputs/feat_blocks.h
+++ b/src/core/models/outputs/feat_blocks.h
@@ -176,6 +176,15 @@ feat_blk_list_t* feat_blk_list_new();
 uint8_t feat_blk_list_len(feat_blk_list_t* list);
 
 /**
+ * @brief Get a feature block pointer by a given type
+ *
+ * @param[in] list A feature block list object
+ * @param[in] type The type of feature block
+ * @return feat_block_t*
+ */
+feat_block_t* feat_blk_list_get_type(feat_blk_list_t* list, feat_block_e type);
+
+/**
  * @brief Get a feature block pointer in the list from a given index
  *
  * @param[in] list A feature list object

--- a/src/core/models/outputs/output_alias.c
+++ b/src/core/models/outputs/output_alias.c
@@ -268,7 +268,7 @@ size_t output_alias_serialize(output_alias_t* output, byte_t buf[], size_t buf_l
   // feature blocks
   if (output->feature_blocks) {
     offset +=
-        feat_blk_list_serialize(output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
+        feat_blk_list_serialize(&output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
   } else {
     memset(offset, 0, sizeof(uint8_t));
     offset += sizeof(uint8_t);

--- a/src/core/models/outputs/output_extended.c
+++ b/src/core/models/outputs/output_extended.c
@@ -173,7 +173,7 @@ size_t output_extended_serialize(output_extended_t* output, byte_t buf[], size_t
   // feature blocks
   if (output->feature_blocks) {
     offset +=
-        feat_blk_list_serialize(output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
+        feat_blk_list_serialize(&output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
   } else {
     memset(offset, 0, sizeof(uint8_t));
     offset += sizeof(uint8_t);

--- a/src/core/models/outputs/output_foundry.c
+++ b/src/core/models/outputs/output_foundry.c
@@ -237,7 +237,7 @@ size_t output_foundry_serialize(output_foundry_t* output, byte_t buf[], size_t b
   // feature blocks
   if (output->feature_blocks) {
     offset +=
-        feat_blk_list_serialize(output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
+        feat_blk_list_serialize(&output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
   } else {
     memset(offset, 0, sizeof(uint8_t));
     offset += sizeof(uint8_t);

--- a/src/core/models/outputs/output_nft.c
+++ b/src/core/models/outputs/output_nft.c
@@ -219,7 +219,7 @@ size_t output_nft_serialize(output_nft_t* output, byte_t buf[], size_t buf_len) 
   // feature blocks
   if (output->feature_blocks) {
     offset +=
-        feat_blk_list_serialize(output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
+        feat_blk_list_serialize(&output->feature_blocks, offset, feat_blk_list_serialize_len(output->feature_blocks));
   } else {
     memset(offset, 0, sizeof(uint8_t));
     offset += sizeof(uint8_t);

--- a/tests/core/test_feat_blocks.c
+++ b/tests/core/test_feat_blocks.c
@@ -238,24 +238,40 @@ void test_feat_block_list_append_all() {
   test_addr.type = ADDRESS_TYPE_ED25519;
   iota_crypto_randombytes(test_addr.address, ADDRESS_ED25519_BYTES);
   TEST_ASSERT(feat_blk_list_add_sender(&blk_list, &test_addr) == 0);
+  // adding 2nd sender should be failed
+  TEST_ASSERT(feat_blk_list_add_sender(&blk_list, &test_addr) != 0);
 
-  // add an issuer
-  test_addr.type = ADDRESS_TYPE_NFT;  // changed the type, but use the same address data
+  // add an issuer, changed the type, but use the same address data
+  test_addr.type = ADDRESS_TYPE_NFT;
   TEST_ASSERT(feat_blk_list_add_issuer(&blk_list, &test_addr) == 0);
+  // adding 2nd issuer should be failed
+  TEST_ASSERT(feat_blk_list_add_issuer(&blk_list, &test_addr) != 0);
+
   // add a metadata
-  byte_t meta_data[256] = {};
+  byte_t meta_data[80] = {};
   iota_crypto_randombytes(meta_data, sizeof(meta_data));
   TEST_ASSERT(feat_blk_list_add_metadata(&blk_list, meta_data, sizeof(meta_data)) == 0);
+  // adding 2nd metadata should be failed
+  TEST_ASSERT(feat_blk_list_add_metadata(&blk_list, meta_data, sizeof(meta_data)) != 0);
+
   // add an indexation tag
   byte_t tag[MAX_INDEX_TAG_BYTES] = {};
   iota_crypto_randombytes(tag, sizeof(tag));
   TEST_ASSERT(feat_blk_list_add_tag(&blk_list, tag, sizeof(tag)) == 0);
+  // adding 2nd tag should be failed
+  TEST_ASSERT(feat_blk_list_add_tag(&blk_list, tag, sizeof(tag)) != 0);
 
   // check length of the list
   TEST_ASSERT(feat_blk_list_len(blk_list) == 4);
 
   // print out the feature block list
   feat_blk_list_print(blk_list, 0);
+
+  // cannot add more block, the MAX block in a list is 4(MAX_FEATURE_BLOCK_COUNT)
+  TEST_ASSERT(feat_blk_list_add_sender(&blk_list, &test_addr) != 0);
+  TEST_ASSERT(feat_blk_list_add_issuer(&blk_list, &test_addr) != 0);
+  TEST_ASSERT(feat_blk_list_add_metadata(&blk_list, meta_data, sizeof(meta_data)) != 0);
+  TEST_ASSERT(feat_blk_list_add_tag(&blk_list, tag, sizeof(tag)) != 0);
 
   // serialization
   size_t exp_ser_len = feat_blk_list_serialize_len(blk_list);
@@ -267,9 +283,9 @@ void test_feat_block_list_append_all() {
   TEST_ASSERT(feat_blk_list_len(deser_list) == feat_blk_list_len(blk_list));
   feat_blk_list_print(deser_list, 0);
 
-  // check deser objects
+  // check deserialized data
   TEST_ASSERT_NULL(feat_blk_list_get(deser_list, feat_blk_list_len(deser_list)));
-  TEST_ASSERT_NULL(feat_blk_list_get(deser_list, UINT8_MAX - 1));
+  TEST_ASSERT_NULL(feat_blk_list_get(deser_list, MAX_FEATURE_BLOCK_COUNT));
   feat_block_t* tmp_blk = NULL;
 
   // 0: should be Sender
@@ -504,9 +520,9 @@ int main() {
   RUN_TEST(test_metadata_one_byte);
   RUN_TEST(test_tag_max);
   RUN_TEST(test_tag_one_byte);
-  // RUN_TEST(test_feat_block_list_append_all);
-  // RUN_TEST(test_feat_block_list_sort);
-  // RUN_TEST(test_feat_block_list_clone);
+  RUN_TEST(test_feat_block_list_append_all);
+  RUN_TEST(test_feat_block_list_sort);
+  RUN_TEST(test_feat_block_list_clone);
 
   return UNITY_END();
 }


### PR DESCRIPTION
# Description of change

This PR
- updated feature block methods 
- added syntactic checks on feature blocks
- added `test_metadata_one_byte` and `test_tag_one_byte` test cases

Test cases failed that caused by output refactoring, need to be fixed:
- `core_output_alias`, should be fixed in #251 
- `core_output_extended`, should be fixed in #252 
- `core_output_foundry`, should be fixed in #253
- `core_output_nft`, should be fixed in #254

## Type of change

- Bugfix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

 `core_feat_blocks` tests passed

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
