### PR TITLE
Client - Remove is_bech32 argument from get outpus method

### DIFF
--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -147,7 +147,7 @@ static int get_outputs_api_call(iota_client_conf_t const *conf, char *cmd_buffer
 }
 
 // TODO: handle querry parameters - requiresDustReturn, sender and tag
-int get_outputs_from_address(iota_client_conf_t const *conf, bool is_bech32, char const addr[], res_outputs_id_t *res) {
+int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res) {
   if (conf == NULL || addr == NULL || res == NULL) {
     // invalid parameters
     return -1;
@@ -160,17 +160,10 @@ int get_outputs_from_address(iota_client_conf_t const *conf, bool is_bech32, cha
   }
 
   // compose restful api command
-  char cmd_buffer[107] = {0};  // 107 = max size of api path(42) + IOTA_ADDRESS_HEX_BYTES(64) + 1
+  char cmd_buffer[105] = {0};  // 105 = max size of api path(40) + IOTA_ADDRESS_HEX_BYTES(64) + 1
   int snprintf_ret;
 
-  if (is_bech32) {
-    snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/plugins/indexer/v1/outputs?addresses=%s", addr);
-  } else {
-    // TODO: handle ed25519 addresses
-    // snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/plugins/indexer/v1/outputs?ed25519=%s",
-    // addr);
-    return -1;
-  }
+  snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/plugins/indexer/v1/outputs?address=%s", addr);
 
   // check if data stored is not more than buffer length
   if (snprintf_ret > (sizeof(cmd_buffer) - 1)) {

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -83,12 +83,11 @@ int deser_outputs(char const *const j_str, res_outputs_id_t *res);
  * @brief Gets output IDs from a given address
  *
  * @param[in] conf The client endpoint configuration
- * @param[in] is_bech32 the address type, true for bech32, false for ed25519
  * @param[in] addr An address in hex string format
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_address(iota_client_conf_t const *conf, bool is_bech32, char const addr[], res_outputs_id_t *res);
+int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given NFT address

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -70,8 +70,7 @@ void test_deser_outputs_err() {
 }
 
 void test_get_output_ids_from_address() {
-  char addr1[] = "017ed3d67fc7b619e72e588f51fef2379e43e6e9a856635843b3f29aa3a3f1f0";
-  char addr_bech32[] = "iota1qpg2xkj66wwgn8p2ggnp7p582gj8g6p79us5hve2tsudzpsr2ap4skprwjg";
+  char addr[] = "atoi1qpl4a3k3dep7qmw4tdq3pss6ld40jr5yhaq4fjakxgmdgk238j5hzsk2xsk";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length =
       "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
@@ -81,16 +80,12 @@ void test_get_output_ids_from_address() {
   TEST_ASSERT_NOT_NULL(res);
 
   // Tests for NULL cases
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, false, NULL, NULL));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, false, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, false, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, true, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, NULL, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(NULL, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, NULL, res));
 
-  // Test invalid address len : ed25519 address
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, false, addr_hex_invalid_length, res));
-
-  // Test invalid address len : bech32 address
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, true, addr_hex_invalid_length, res));
+  // Test invalid address len
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_address(&ctx, addr_hex_invalid_length, res));
 
   // Re initializing res
   res_outputs_free(res);
@@ -98,8 +93,8 @@ void test_get_output_ids_from_address() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // Test invalid ED25519 address
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, false, addr_hex_invalid, res));
+  // Test invalid address
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, addr_hex_invalid, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
@@ -111,45 +106,10 @@ void test_get_output_ids_from_address() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // Test invalid BECH32 address
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_address(&ctx, true, addr_hex_invalid, res));
-  TEST_ASSERT(res->is_error);
-  if (res->is_error == true) {
-    printf("Error: %s\n", res->u.error->msg);
-  }
-
-  // Re initializing res
-  res_outputs_free(res);
-  res = NULL;
-  res = res_outputs_new();
-  TEST_ASSERT_NOT_NULL(res);
-
-  // Tests for ed25519 address
-  int ret = get_outputs_from_address(&ctx, false, addr1, res);
+  int ret = get_outputs_from_address(&ctx, addr, res);
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);
 
-  // Re initializing res
-  res_outputs_free(res);
-  res = NULL;
-  res = res_outputs_new();
-  TEST_ASSERT_NOT_NULL(res);
-
-  // Tests for bech32 address
-  ret = get_outputs_from_address(&ctx, true, addr_bech32, res);
-  TEST_ASSERT(ret == 0);
-  TEST_ASSERT(res->is_error == false);
-
-// TODO, validate addresses
-#if 0
-  char addr_hex_str[ADDRESS_ED25519_HEX_BYTES+ 1] = {0};
-  TEST_ASSERT(address_bech32_to_hex("iota", addr_bech32, addr_hex_str, sizeof(addr_hex_str)) == 0);
-  // Converting hex string to lower case to check equality
-  for (int i = 0; i < ADDRESS_ED25519_HEX_BYTES; i++) {
-    addr_hex_str[i] = tolower(addr_hex_str[i]);
-  }
-  TEST_ASSERT_EQUAL_MEMORY(addr_hex_str, res->u.output_ids->address, ADDRESS_ED25519_HEX_BYTES);
-#endif
   res_outputs_free(res);
 }
 


### PR DESCRIPTION
# Description of change

Remving is_bech32 argument frm get_outputs_from_address method, as we currently only dealing with bech32 address. Ed25519 address method and test case.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

test_outputs_id.c
Tested using private tangle :
#define TEST_TANGLE_ENABLE 1
#define TEST_NODE_HOST "0.0.0.0"
#define TEST_NODE_PORT 14265
#define TEST_IS_HTTPS 0
Success response from tangle :
`{"ledgerIndex":563,"limit":1000,"count":2,"data":["344a352b338bc450cf530c88dfc92bec5cac2407133aaa54209be02b5d37912f0000","101a247daad0a44fe1dac02233abd17cc27dd79837c1838f4aa1fa60f688ae840000"]}`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
