### PR TITLE
Client  - Outputs id api querry parameters

### DIFF
--- a/docs/api/restful.md
+++ b/docs/api/restful.md
@@ -141,7 +141,7 @@ The RESTful API is low level client implementation based on [RFC: REST Node API]
 ## [Get Outputs From Address](https://github.com/iotaledger/iota.c/blob/dev/src/client/api/restful/get_outputs_id.h)
 
 ```{eval-rst}
-.. doxygenfunction:: get_outputs_from_address
+.. doxygenfunction:: get_outputs_id
 ```
 
 ### Response

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -391,7 +391,7 @@ int get_outputs_from_nft_address(iota_client_conf_t const *conf, char const addr
   return get_outputs_api_call(conf, cmd_buffer, res);
 }
 
-int get_outputs_from_alias(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res) {
+int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res) {
   if (conf == NULL || res == NULL) {
     printf("[%s:%d] invalid parameter\n", __func__, __LINE__);
     return -1;

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -19,6 +19,11 @@
 #define OUTPUTS_QUERY_GOV_KEY "governor"
 #define OUTPUTS_QUERY_ISSUER_KEY "issuer"
 
+#define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
+#define INDEXER_ALIASES_API_PATH "/api/plugins/indexer/v1/aliases"
+#define INDEXER_NFT_API_PATH "/api/plugins/indexer/v1/nfts"
+#define INDEXER_FOUNDRY_API_PATH "/api/plugins/indexer/v1/foundries"
+
 outputs_query_list_t *outputs_query_list_new() { return NULL; }
 
 int outputs_query_list_add(outputs_query_list_t **list, outputs_query_params_e type, char const *const param) {
@@ -53,7 +58,7 @@ size_t get_outputs_query_str_len(outputs_query_list_t *list) {
         query_str_len += strlen(elm->query_item->param);
         query_str_len += 2;  // For "&" params seperator and "=" params assignment
         break;
-      case QUERY_PARAM_DUST_RET:
+      case QUERY_PARAM_HAS_DUST_RET:
         query_str_len += strlen(OUTPUTS_QUERY_DUST_RET_KEY);
         query_str_len += strlen(elm->query_item->param);
         query_str_len += 2;  // For "&" params seperator and "=" params assignment
@@ -139,7 +144,7 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
       case QUERY_PARAM_ADDRESS:
         offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_ADDRESS_KEY, elm);
         break;
-      case QUERY_PARAM_DUST_RET:
+      case QUERY_PARAM_HAS_DUST_RET:
         offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_DUST_RET_KEY, elm);
         break;
       case QUERY_PARAM_DUST_RET_ADDR:
@@ -369,7 +374,6 @@ static char *compose_api_command(outputs_query_list_t *list, char const *const a
     memcpy(cmd_buffer + api_path_len + 1, query_str, query_str_len + 1);
     free(query_str);
   } else {
-    printf("Reached here\n");
     cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
     if (!cmd_buffer) {
       printf("[%s:%d]: OOM\n", __func__, __LINE__);

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -124,7 +124,7 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
   // Check if buffer length is sufficient for holding query string
   size_t query_str_len = get_outputs_query_str_len(list);
   if (query_str_len == 0) {
-    printf("[%s:%d] No Element in Listn", __func__, __LINE__);
+    printf("[%s:%d] No element in query list\n", __func__, __LINE__);
     return 0;
   }
   if (buf_len < query_str_len + 1) {

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -9,6 +9,10 @@
 #include "utlist.h"
 
 #define OUTPUTS_QUERY_ADDRESS_KEY "address"
+#define OUTPUTS_QUERY_DUST_RET_KEY "hasDustReturnCondition"
+#define OUTPUTS_QUERY_DUST_RET_ADDR_KEY "dustReturnAddress"
+#define OUTPUTS_QUERY_SENDER_KEY "sender"
+#define OUTPUTS_QUERY_TAG_KEY "tag"
 #define OUTPUTS_QUERY_PAGE_SIZE_KEY "pageSize"
 #define OUTPUTS_QUERY_CURSOR_KEY "cursor"
 
@@ -38,6 +42,26 @@ size_t get_outputs_query_str_len(outputs_query_list_t *list) {
     switch (elm->query_item->type) {
       case QUERY_PARAM_ADDRESS:
         query_str_len += strlen(OUTPUTS_QUERY_ADDRESS_KEY);
+        query_str_len += strlen(elm->query_item->param);
+        query_str_len += 2;  // For "&" params seperator and "=" params assignment
+        break;
+      case QUERY_PARAM_DUST_RET:
+        query_str_len += strlen(OUTPUTS_QUERY_DUST_RET_KEY);
+        query_str_len += strlen(elm->query_item->param);
+        query_str_len += 2;  // For "&" params seperator and "=" params assignment
+        break;
+      case QUERY_PARAM_DUST_RET_ADDR:
+        query_str_len += strlen(OUTPUTS_QUERY_DUST_RET_ADDR_KEY);
+        query_str_len += strlen(elm->query_item->param);
+        query_str_len += 2;  // For "&" params seperator and "=" params assignment
+        break;
+      case QUERY_PARAM_SENDER:
+        query_str_len += strlen(OUTPUTS_QUERY_SENDER_KEY);
+        query_str_len += strlen(elm->query_item->param);
+        query_str_len += 2;  // For "&" params seperator and "=" params assignment
+        break;
+      case QUERY_PARAM_TAG:
+        query_str_len += strlen(OUTPUTS_QUERY_TAG_KEY);
         query_str_len += strlen(elm->query_item->param);
         query_str_len += 2;  // For "&" params seperator and "=" params assignment
         break;
@@ -83,6 +107,18 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
     switch (elm->query_item->type) {
       case QUERY_PARAM_ADDRESS:
         offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_ADDRESS_KEY, elm);
+        break;
+      case QUERY_PARAM_DUST_RET:
+        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_DUST_RET_KEY, elm);
+        break;
+      case QUERY_PARAM_DUST_RET_ADDR:
+        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_DUST_RET_ADDR_KEY, elm);
+        break;
+      case QUERY_PARAM_SENDER:
+        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_SENDER_KEY, elm);
+        break;
+      case QUERY_PARAM_TAG:
+        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_TAG_KEY, elm);
         break;
       case QUERY_PARAM_PAGE_SIZE:
         offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_PAGE_SIZE_KEY, elm);
@@ -254,6 +290,7 @@ static int get_outputs_api_call(iota_client_conf_t const *conf, char *cmd_buffer
   // send request via http client
   if ((ret = http_client_get(&http_conf, http_res, &st)) == 0) {
     byte_buf2str(http_res);
+    printf("Response : %s\n", http_res->data);
     // json deserialization
     ret = deser_outputs((char const *const)http_res->data, res);
   }
@@ -298,6 +335,8 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
     // copy api path
     memcpy(cmd_buffer, INDEXER_OUTPUTS_API_PATH, api_path_len + 1);
   }
+
+  printf("CMD_BUFFER : %s\n", cmd_buffer);
 
   return get_outputs_api_call(conf, cmd_buffer, res);
 }

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -25,20 +25,17 @@ int outputs_query_list_add(outputs_query_list_t **list, outputs_query_params_e t
   outputs_query_list_t *next = malloc(sizeof(outputs_query_list_t));
   if (next) {
     next->query_item = malloc(sizeof(outputs_query_params_t));
-    if (!next->query_item) {
-      printf("[%s:%d]: OOM\n", __func__, __LINE__);
-      return -1;
-    }
-    next->query_item->type = type;
-    next->query_item->param = malloc(strlen(param) + 1);
-    if (!next->query_item->param) {
-      printf("[%s:%d]: OOM\n", __func__, __LINE__);
-      return -1;
-    }
-    memcpy(next->query_item->param, param, strlen(param) + 1);
     if (next->query_item) {
-      LL_APPEND(*list, next);
-      return 0;
+      next->query_item->type = type;
+      next->query_item->param = malloc(strlen(param) + 1);
+      if (next->query_item->param) {
+        memcpy(next->query_item->param, param, strlen(param) + 1);
+        LL_APPEND(*list, next);
+        return 0;
+      } else {
+        free(next->query_item);
+        free(next);
+      }
     } else {
       free(next);
     }

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -102,7 +102,10 @@ size_t get_outputs_query_str_len(outputs_query_list_t *list) {
         break;
     }
   }
-  query_str_len--;  // Remove the "&" params seperator at the end
+  // check if there was at least one item in the list
+  if (query_str_len > 0) {
+    query_str_len--;  // Remove the "&" params seperator at the end
+  }
   return query_str_len;
 }
 
@@ -120,8 +123,13 @@ static int copy_param_to_buf(char *buf, size_t offset, char *key, outputs_query_
 size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_len) {
   // Check if buffer length is sufficient for holding query string
   size_t query_str_len = get_outputs_query_str_len(list);
+  if (query_str_len == 0) {
+    printf("[%s:%d] No Element in Listn", __func__, __LINE__);
+    return 0;
+  }
   if (buf_len < query_str_len + 1) {
     printf("[%s:%d] buffer length not sufficient\n", __func__, __LINE__);
+    return 0;
   }
 
   size_t offset = 0;
@@ -162,7 +170,9 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
         break;
     }
   }
-  buf[offset - 1] = 0;  // Replace the "&" at the end with '\0'
+  if (buf[offset - 1] == '&') {
+    buf[offset - 1] = 0;  // Replace the "&" at the end with '\0'
+  }
   return offset;
 }
 

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -109,15 +109,15 @@ size_t get_outputs_query_str_len(outputs_query_list_t *list) {
   return query_str_len;
 }
 
-static int copy_param_to_buf(char *buf, size_t offset, char *key, outputs_query_list_t *elm) {
-  int len = offset;
-  memcpy(buf + offset, key, strlen(key));
-  offset += strlen(key);
-  buf[offset++] = '=';
-  memcpy(buf + offset, elm->query_item->param, strlen(elm->query_item->param));
-  offset += strlen(elm->query_item->param);
-  buf[offset++] = '&';
-  return offset - len;
+static int copy_param_to_buf(char *buf, char *key, outputs_query_list_t *elm) {
+  int len = 0;
+  memcpy(buf + len, key, strlen(key));
+  len += strlen(key);
+  buf[len++] = '=';
+  memcpy(buf + len, elm->query_item->param, strlen(elm->query_item->param));
+  len += strlen(elm->query_item->param);
+  buf[len++] = '&';
+  return len;
 }
 
 size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_len) {
@@ -137,34 +137,34 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
   LL_FOREACH(list, elm) {
     switch (elm->query_item->type) {
       case QUERY_PARAM_ADDRESS:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_ADDRESS_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_ADDRESS_KEY, elm);
         break;
       case QUERY_PARAM_DUST_RET:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_DUST_RET_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_DUST_RET_KEY, elm);
         break;
       case QUERY_PARAM_DUST_RET_ADDR:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_DUST_RET_ADDR_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_DUST_RET_ADDR_KEY, elm);
         break;
       case QUERY_PARAM_SENDER:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_SENDER_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_SENDER_KEY, elm);
         break;
       case QUERY_PARAM_TAG:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_TAG_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_TAG_KEY, elm);
         break;
       case QUERY_PARAM_PAGE_SIZE:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_PAGE_SIZE_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_PAGE_SIZE_KEY, elm);
         break;
       case QUERY_PARAM_CURSOR:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_CURSOR_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_CURSOR_KEY, elm);
         break;
       case QUERY_PARAM_STATE_CTRL:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_STATE_CTRL_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_STATE_CTRL_KEY, elm);
         break;
       case QUERY_PARAM_GOV:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_GOV_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_GOV_KEY, elm);
         break;
       case QUERY_PARAM_ISSUER:
-        offset += copy_param_to_buf(buf, offset, OUTPUTS_QUERY_ISSUER_KEY, elm);
+        offset += copy_param_to_buf(buf + offset, OUTPUTS_QUERY_ISSUER_KEY, elm);
         break;
       default:
         break;

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -290,7 +290,6 @@ static int get_outputs_api_call(iota_client_conf_t const *conf, char *cmd_buffer
   // send request via http client
   if ((ret = http_client_get(&http_conf, http_res, &st)) == 0) {
     byte_buf2str(http_res);
-    printf("Response : %s\n", http_res->data);
     // json deserialization
     ret = deser_outputs((char const *const)http_res->data, res);
   }
@@ -335,8 +334,6 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
     // copy api path
     memcpy(cmd_buffer, INDEXER_OUTPUTS_API_PATH, api_path_len + 1);
   }
-
-  printf("CMD_BUFFER : %s\n", cmd_buffer);
 
   return get_outputs_api_call(conf, cmd_buffer, res);
 }

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -25,8 +25,16 @@ int outputs_query_list_add(outputs_query_list_t **list, outputs_query_params_e t
   outputs_query_list_t *next = malloc(sizeof(outputs_query_list_t));
   if (next) {
     next->query_item = malloc(sizeof(outputs_query_params_t));
+    if (!next->query_item) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     next->query_item->type = type;
     next->query_item->param = malloc(strlen(param) + 1);
+    if (!next->query_item->param) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     memcpy(next->query_item->param, param, strlen(param) + 1);
     if (next->query_item) {
       LL_APPEND(*list, next);
@@ -348,6 +356,10 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
       return -1;
     }
     cmd_buffer = malloc(api_path_len + 1 + query_str_len + 1);  // api_path + '?' + query_str + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_OUTPUTS_API_PATH, api_path_len);
     // add "?" query symbol
@@ -357,6 +369,10 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
     free(query_str);
   } else {
     cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_OUTPUTS_API_PATH, api_path_len + 1);
   }
@@ -390,6 +406,10 @@ int get_nft_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, 
       return -1;
     }
     cmd_buffer = malloc(api_path_len + 1 + query_str_len + 1);  // api_path + '?' + query_str + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_NFT_API_PATH, api_path_len);
     // add "?" query symbol
@@ -399,6 +419,10 @@ int get_nft_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, 
     free(query_str);
   } else {
     cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_NFT_API_PATH, api_path_len + 1);
   }
@@ -432,6 +456,10 @@ int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list
       return -1;
     }
     cmd_buffer = malloc(api_path_len + 1 + query_str_len + 1);  // api_path + '?' + query_str + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_ALIASES_API_PATH, api_path_len);
     // add "?" query symbol
@@ -441,6 +469,10 @@ int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list
     free(query_str);
   } else {
     cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_ALIASES_API_PATH, api_path_len + 1);
   }
@@ -474,6 +506,10 @@ int get_foundry_outputs(iota_client_conf_t const *conf, outputs_query_list_t *li
       return -1;
     }
     cmd_buffer = malloc(api_path_len + 1 + query_str_len + 1);  // api_path + '?' + query_str + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_FOUNDRY_API_PATH, api_path_len);
     // add "?" query symbol
@@ -483,6 +519,10 @@ int get_foundry_outputs(iota_client_conf_t const *conf, outputs_query_list_t *li
     free(query_str);
   } else {
     cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
+    if (!cmd_buffer) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
     // copy api path
     memcpy(cmd_buffer, INDEXER_FOUNDRY_API_PATH, api_path_len + 1);
   }

--- a/src/client/api/restful/get_outputs_id.c
+++ b/src/client/api/restful/get_outputs_id.c
@@ -321,7 +321,6 @@ static int get_outputs_api_call(iota_client_conf_t const *conf, char *cmd_buffer
     ret = deser_outputs((char const *const)http_res->data, res);
   }
   byte_buf_free(http_res);
-  free(cmd_buffer);
   return ret;
 }
 
@@ -362,7 +361,9 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
     memcpy(cmd_buffer, INDEXER_OUTPUTS_API_PATH, api_path_len + 1);
   }
 
-  return get_outputs_api_call(conf, cmd_buffer, res);
+  int ret = get_outputs_api_call(conf, cmd_buffer, res);
+  free(cmd_buffer);
+  return ret;
 }
 
 int get_nft_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res) {
@@ -402,7 +403,9 @@ int get_nft_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, 
     memcpy(cmd_buffer, INDEXER_NFT_API_PATH, api_path_len + 1);
   }
 
-  return get_outputs_api_call(conf, cmd_buffer, res);
+  int ret = get_outputs_api_call(conf, cmd_buffer, res);
+  free(cmd_buffer);
+  return ret;
 }
 
 int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res) {
@@ -442,32 +445,51 @@ int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list
     memcpy(cmd_buffer, INDEXER_ALIASES_API_PATH, api_path_len + 1);
   }
 
-  return get_outputs_api_call(conf, cmd_buffer, res);
+  int ret = get_outputs_api_call(conf, cmd_buffer, res);
+  free(cmd_buffer);
+  return ret;
 }
 
-int get_outputs_from_foundry_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res) {
-  if (conf == NULL || addr == NULL || res == NULL) {
+int get_foundry_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res) {
+  if (conf == NULL || res == NULL) {
     printf("[%s:%d] invalid parameter\n", __func__, __LINE__);
     return -1;
   }
 
-  size_t addr_len = strlen(addr);
-  if (addr_len != BECH32_ENCODED_ALIAS_ADDRESS) {
-    printf("[%s:%d] incorrect length of an address\n", __func__, __LINE__);
-    return -1;
-  }
-
   // compose restful api command
-  char cmd_buffer[88] = {0};  // 88 = max size of api path(42) + BECH32_ENCODED_ALIAS_ADDRESS(45) + 1
-  int snprintf_ret = snprintf(cmd_buffer, sizeof(cmd_buffer), "/api/plugins/indexer/v1/foundries?address=%s", addr);
+  char *cmd_buffer;
+  size_t api_path_len = strlen(INDEXER_FOUNDRY_API_PATH);
 
-  // check if data stored is not more than buffer length
-  if (snprintf_ret > (sizeof(cmd_buffer) - 1)) {
-    printf("[%s:%d]: http cmd buffer overflow\n", __func__, __LINE__);
-    return -1;
+  if (list) {
+    size_t query_str_len = get_outputs_query_str_len(list);
+    char *query_str = malloc(query_str_len + 1);
+    if (!query_str) {
+      printf("[%s:%d]: OOM\n", __func__, __LINE__);
+      return -1;
+    }
+    size_t len = get_outputs_query_str(list, query_str, query_str_len + 1);
+    if (len != query_str_len + 1) {
+      printf("[%s:%d]: Query string len and copied data mismatch\n", __func__, __LINE__);
+      free(query_str);
+      return -1;
+    }
+    cmd_buffer = malloc(api_path_len + 1 + query_str_len + 1);  // api_path + '?' + query_str + '\0'
+    // copy api path
+    memcpy(cmd_buffer, INDEXER_FOUNDRY_API_PATH, api_path_len);
+    // add "?" query symbol
+    cmd_buffer[api_path_len] = '?';
+    // copy query strings
+    memcpy(cmd_buffer + api_path_len + 1, query_str, query_str_len + 1);
+    free(query_str);
+  } else {
+    cmd_buffer = malloc(api_path_len + 1);  // api_path + '\0'
+    // copy api path
+    memcpy(cmd_buffer, INDEXER_FOUNDRY_API_PATH, api_path_len + 1);
   }
 
-  return get_outputs_api_call(conf, cmd_buffer, res);
+  int ret = get_outputs_api_call(conf, cmd_buffer, res);
+  free(cmd_buffer);
+  return ret;
 }
 
 int get_outputs_from_nft_id(iota_client_conf_t const *conf, char const nft_id[], res_outputs_id_t *res) {

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -12,6 +12,7 @@
 #include "core/types.h"
 
 #define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
+#define INDEXER_ALIASES_API_PATH "/api/plugins/indexer/v1/aliases"
 
 /**
  * @brief All Query Params Type
@@ -180,11 +181,11 @@ int get_outputs_from_nft_address(iota_client_conf_t const *conf, char const addr
  * @brief Gets output IDs from a given Alias address
  *
  * @param[in] conf The client endpoint configuration
- * @param[in] addr An Alias address in hex string format
+ * @param[in] list A list of optional query params
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_alias_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res);
+int get_outputs_from_alias(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given Foundry address

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -108,6 +108,7 @@ size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_l
  *
  */
 void outputs_query_list_free(outputs_query_list_t *list);
+
 /**
  * @brief Allocats an output address response object
  *
@@ -152,11 +153,11 @@ int deser_outputs(char const *const j_str, res_outputs_id_t *res);
  * @brief Gets output IDs from a given address
  *
  * @param[in] conf The client endpoint configuration
- * @param[in] addr An address in hex string format
+ * @param[in] list A list of optional query params
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res);
+int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given NFT address

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -11,18 +11,13 @@
 #include "core/address.h"
 #include "core/types.h"
 
-#define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
-#define INDEXER_ALIASES_API_PATH "/api/plugins/indexer/v1/aliases"
-#define INDEXER_NFT_API_PATH "/api/plugins/indexer/v1/nfts"
-#define INDEXER_FOUNDRY_API_PATH "/api/plugins/indexer/v1/foundries"
-
 /**
  * @brief All Query Params Type
  *
  */
 typedef enum {
   QUERY_PARAM_ADDRESS = 0,    ///< The Bech32-encoded address that should be used to query outputs
-  QUERY_PARAM_DUST_RET,       ///< The presence of dust return unlock condition
+  QUERY_PARAM_HAS_DUST_RET,   ///< The presence of dust return unlock condition
   QUERY_PARAM_DUST_RET_ADDR,  ///< The specific return address in the dust deposit return unlock condition
   QUERY_PARAM_SENDER,         ///< To query outputs based on bech32-encoded sender address.
   QUERY_PARAM_TAG,            ///< A tag block to search for outputs matching it
@@ -34,7 +29,7 @@ typedef enum {
 } outputs_query_params_e;
 
 /**
- * @brief A Query Param Onject
+ * @brief A Query Param Object
  *
  */
 typedef struct {
@@ -86,7 +81,7 @@ extern "C" {
 outputs_query_list_t *outputs_query_list_new();
 
 /**
- * @brief Add a querry parameter to the list
+ * @brief Add a query parameter to the list
  *
  * @param[in] list A query item list
  * @param[in] type A query parameter type

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -14,6 +14,7 @@
 #define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
 #define INDEXER_ALIASES_API_PATH "/api/plugins/indexer/v1/aliases"
 #define INDEXER_NFT_API_PATH "/api/plugins/indexer/v1/nfts"
+#define INDEXER_FOUNDRY_API_PATH "/api/plugins/indexer/v1/foundries"
 
 /**
  * @brief All Query Params Type
@@ -192,11 +193,11 @@ int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list
  * @brief Gets output IDs from a given Foundry address
  *
  * @param[in] conf The client endpoint configuration
- * @param[in] addr A Foundry address in hex string format
+ * @param[in] list A list of optional query params
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_foundry_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res);
+int get_foundry_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given NFT ID

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -185,7 +185,7 @@ int get_outputs_from_nft_address(iota_client_conf_t const *conf, char const addr
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_alias(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
+int get_alias_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given Foundry address

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -13,6 +13,7 @@
 
 #define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
 #define INDEXER_ALIASES_API_PATH "/api/plugins/indexer/v1/aliases"
+#define INDEXER_NFT_API_PATH "/api/plugins/indexer/v1/nfts"
 
 /**
  * @brief All Query Params Type
@@ -175,7 +176,7 @@ int get_outputs_id(iota_client_conf_t const *conf, outputs_query_list_t *list, r
  * @param[out] res A response object
  * @return int 0 on successful
  */
-int get_outputs_from_nft_address(iota_client_conf_t const *conf, char const addr[], res_outputs_id_t *res);
+int get_nft_outputs(iota_client_conf_t const *conf, outputs_query_list_t *list, res_outputs_id_t *res);
 
 /**
  * @brief Gets output IDs from a given Alias address

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -11,6 +11,36 @@
 #include "core/address.h"
 #include "core/types.h"
 
+#define INDEXER_OUTPUTS_API_PATH "/api/plugins/indexer/v1/outputs"
+
+/**
+ * @brief All Query Params Type
+ *
+ */
+typedef enum {
+  QUERY_PARAM_ADDRESS = 0,  ///< The Bech32-encoded address that should be used to query outputs
+  QUERY_PARAM_PAGE_SIZE,    ///< The maximum amount of items returned in one api call
+  QUERY_PARAM_CURSOR        ///<  A cursor to start the query (confirmationMS+outputId.pageSize)
+} outputs_query_params_e;
+
+/**
+ * @brief A Query Param Onject
+ *
+ */
+typedef struct {
+  outputs_query_params_e type;  ///< The type of query param
+  char *param;                  ///< Query param data
+} outputs_query_params_t;
+
+/**
+ * @brief A list of outputs query parameters
+ *
+ */
+typedef struct outputs_query_list {
+  outputs_query_params_t *query_item;  ///< Points to a query parameter object
+  struct outputs_query_list *next;     ///< Points to next query parameter object
+} outputs_query_list_t;
+
 /**
  * @brief An output object
  *
@@ -38,6 +68,46 @@ typedef struct {
 extern "C" {
 #endif
 
+/**
+ * @brief New outputs query params list
+ *
+ * @return outputs_query_list_t*
+ */
+outputs_query_list_t *outputs_query_list_new();
+
+/**
+ * @brief Add a querry parameter to the list
+ *
+ * @param[in] list A query item list
+ * @param[in] type A query parameter type
+ * @param[in] param A query parameter
+ * @return int 0 on success
+ */
+int outputs_query_list_add(outputs_query_list_t **list, outputs_query_params_e type, char const *const param);
+
+/**
+ * @brief Get the length of query string present in list
+ *
+ * @param[in] list A query item list
+ * @return size_t Query string len
+ */
+size_t get_outputs_query_str_len(outputs_query_list_t *list);
+
+/**
+ * @brief Get the query string present in list
+ *
+ * @param[in] list A query item list
+ * @param[in] buf A buffer to hold query string
+ * @param[in] buf_len The length of the buffer
+ * @return size_t Query string len
+ */
+size_t get_outputs_query_str(outputs_query_list_t *list, char *buf, size_t buf_len);
+
+/**
+ * @brief Free query list
+ *
+ */
+void outputs_query_list_free(outputs_query_list_t *list);
 /**
  * @brief Allocats an output address response object
  *

--- a/src/client/api/restful/get_outputs_id.h
+++ b/src/client/api/restful/get_outputs_id.h
@@ -18,9 +18,16 @@
  *
  */
 typedef enum {
-  QUERY_PARAM_ADDRESS = 0,  ///< The Bech32-encoded address that should be used to query outputs
-  QUERY_PARAM_PAGE_SIZE,    ///< The maximum amount of items returned in one api call
-  QUERY_PARAM_CURSOR        ///<  A cursor to start the query (confirmationMS+outputId.pageSize)
+  QUERY_PARAM_ADDRESS = 0,    ///< The Bech32-encoded address that should be used to query outputs
+  QUERY_PARAM_DUST_RET,       ///< The presence of dust return unlock condition
+  QUERY_PARAM_DUST_RET_ADDR,  ///< The specific return address in the dust deposit return unlock condition
+  QUERY_PARAM_SENDER,         ///< To query outputs based on bech32-encoded sender address.
+  QUERY_PARAM_TAG,            ///< A tag block to search for outputs matching it
+  QUERY_PARAM_PAGE_SIZE,      ///< The maximum amount of items returned in one api call
+  QUERY_PARAM_CURSOR,         ///<  A cursor to start the query (confirmationMS+outputId.pageSize)
+  QUERY_PARAM_STATE_CTRL,     ///< To query outputs based on bech32-encoded state controller address
+  QUERY_PARAM_GOV,            ///< To query outputs based on bech32-encoded governor (governance controller) address
+  QUERY_PARAM_ISSUER          ///< To query outputs based on bech32-encoded issuer address
 } outputs_query_params_e;
 
 /**

--- a/src/wallet/wallet.c
+++ b/src/wallet/wallet.c
@@ -130,7 +130,8 @@ static transaction_payload_t* wallet_build_transaction(iota_wallet_t* w, bool ch
     return NULL;
   }
 
-  if (get_outputs_from_address(&w->endpoint, false, tmp_addr, outputs_res) != 0) {
+  // FIXME : get_outputs_id method now accepts query params list
+  if (get_outputs_id(&w->endpoint, false, tmp_addr, outputs_res) != 0) {
     printf("[%s:%d] Err: get outputs from address failed\n", __func__, __LINE__);
     goto done;
   }

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -300,7 +300,7 @@ void test_get_output_ids_from_nft_address() {
   res_outputs_free(res);
 }
 
-void test_get_output_ids_from_alias() {
+void test_get_alias_outputs() {
   char addr_alias[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
@@ -583,7 +583,7 @@ int main() {
 #if TEST_TANGLE_ENABLE
   RUN_TEST(test_get_output_ids);
   RUN_TEST(test_get_output_ids_from_nft_address);
-  RUN_TEST(test_get_output_ids_from_alias);
+  RUN_TEST(test_get_alias_outputs);
   RUN_TEST(test_get_output_ids_from_foundry_address);
   RUN_TEST(test_get_output_ids_from_nft_id);
   RUN_TEST(test_get_output_ids_from_alias_id);

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -21,7 +21,7 @@ void test_query_params() {
       "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   outputs_query_list_t* list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
-  // Check len qyery string len for empty list
+  // Check query string len with an empty list
   size_t query_str_len = get_outputs_query_str_len(list);
   TEST_ASSERT_EQUAL(0, query_str_len);
   char query_str[10];
@@ -128,7 +128,7 @@ void test_get_output_ids() {
   char dust_ret_addr[] = "atoi1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluehe53e";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length =
-      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+      "atoi1qpl4a3k3dep7qmw4tdq3pss6ld40jr5yhaq4fjakxgmdgk238j5hzsk2xsk3efg256shxtb7812b";
   char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   char const* const tag = "4ec7f23a";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
@@ -222,8 +222,8 @@ void test_get_output_ids() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
 
-  // TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "true") == 0);
-  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "false") == 0);
+  // TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_HAS_DUST_RET, "true") == 0);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_HAS_DUST_RET, "false") == 0);
   ret = get_outputs_id(&ctx, list, res);
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);
@@ -265,7 +265,7 @@ void test_get_output_ids() {
 void test_get_nft_output() {
   char addr_nft[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const addr_hex_invalid_length = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn426sdvcxjxsb628726zxsb";
   char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
@@ -323,25 +323,13 @@ void test_get_nft_output() {
   TEST_ASSERT_EQUAL_INT(0, get_nft_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
-  //=====Test valid nft address=====
-  outputs_query_list_free(list);
-  res_outputs_free(res);
-  res = NULL;
-  res = res_outputs_new();
-  TEST_ASSERT_NOT_NULL(res);
-  list = outputs_query_list_new();
-  TEST_ASSERT_NULL(list);
-  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr_nft) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_nft_outputs(&ctx, list, res));
-  TEST_ASSERT(res->is_error == false);
-
   //=====Test dust return condition=====
   res_outputs_free(res);
   res = NULL;
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
-  // TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "true") == 0);
-  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "false") == 0);
+  // TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_HAS_DUST_RET, "true") == 0);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_HAS_DUST_RET, "false") == 0);
   int ret = get_nft_outputs(&ctx, list, res);
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);
@@ -403,7 +391,7 @@ void test_get_nft_output() {
 void test_get_alias_outputs() {
   char addr_alias[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const addr_hex_invalid_length = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwnfgs527svshx5275";
   char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
@@ -498,7 +486,7 @@ void test_get_alias_outputs() {
 void test_get_foundry_outputs() {
   char addr_alias[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const addr_hex_invalid_length = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwndsjsh5262725sgnb";
   char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
@@ -583,7 +571,7 @@ void test_get_foundry_outputs() {
 void test_get_output_ids_from_nft_id() {
   char nft_id[] = "efdc112efe262b304bcf379b26c31bad029f61de";
   char const* const id_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const id_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const id_invalid_length = "efdc112efe262b304bcf379b26c31bad029f61def346ab52ef";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();
@@ -628,7 +616,7 @@ void test_get_output_ids_from_nft_id() {
 void test_get_output_ids_from_alias_id() {
   char alias_id[] = "23dc192ede262b3f4bce379b26c31bad029f62fe";
   char const* const id_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const id_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const id_invalid_length = "23dc192ede262b3f4bce379b26c31bad029f62fe246ec78";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();
@@ -673,7 +661,7 @@ void test_get_output_ids_from_alias_id() {
 void test_get_output_ids_from_foundry_id() {
   char foundry_id[] = "56ec192ede262b3f4bce379b26c31bad029f63bc23ef56ee48cf";
   char const* const id_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-  char const* const id_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const id_invalid_length = "56ec192ede262b3f4bce379b26c31bad029f63bc23ef56ee48cf257efc375";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -300,51 +300,99 @@ void test_get_output_ids_from_nft_address() {
   res_outputs_free(res);
 }
 
-void test_get_output_ids_from_alias_address() {
+void test_get_output_ids_from_alias() {
   char addr_alias[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
 
   //=====Tests for parameters NULL cases=====
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias_address(NULL, addr_alias, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias_address(&ctx, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias_address(&ctx, addr_alias, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias(NULL, NULL, res));
+
+  // Test for case without query params
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, NULL, res));
+  TEST_ASSERT(res->is_error == false);
+
+  outputs_query_list_t* list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_alias) == 0);
+  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias(&ctx, list, NULL));
 
   //=====Test invalid address len=====
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias_address(&ctx, addr_hex_invalid_length, res));
-
-  /* FIXME : invalid address is returning empty response without error. Fix this once aliases api has handled invalid
-   addresses
-   // Re initializing res
-   res_outputs_free(res);
-   res = NULL;
-   res = res_outputs_new();
-   TEST_ASSERT_NOT_NULL(res);
-
-   //=====Test invalid alias address=====
-
-   TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias_address(&ctx, addr_hex_invalid, res));
-   TEST_ASSERT(res->is_error);
-   if (res->is_error == true) {
-     printf("Error: %s\n", res->u.error->msg);
-   }
- */
-  // Re initializing res
   res_outputs_free(res);
   res = NULL;
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_hex_invalid_length) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
+
+  //=====Test invalid alias address=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_hex_invalid) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
 
   //=====Test valid alias address=====
-  int ret = get_outputs_from_alias_address(&ctx, addr_alias, res);
-  TEST_ASSERT(ret == 0);
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_alias) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT(res->is_error == false);
+
+  //=====Test issuer address=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ISSUER, addr_alias) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT(res->is_error == false);
+
+  //=====Test Page Size=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_PAGE_SIZE, "2") == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT(res->is_error == false);
+
+  //=====Test Cursor=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_CURSOR, cursor) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   res_outputs_free(res);
+  outputs_query_list_free(list);
 }
 
 void test_get_output_ids_from_foundry_address() {
@@ -535,7 +583,7 @@ int main() {
 #if TEST_TANGLE_ENABLE
   RUN_TEST(test_get_output_ids);
   RUN_TEST(test_get_output_ids_from_nft_address);
-  RUN_TEST(test_get_output_ids_from_alias_address);
+  RUN_TEST(test_get_output_ids_from_alias);
   RUN_TEST(test_get_output_ids_from_foundry_address);
   RUN_TEST(test_get_output_ids_from_nft_id);
   RUN_TEST(test_get_output_ids_from_alias_id);

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -311,16 +311,16 @@ void test_get_alias_outputs() {
   TEST_ASSERT_NOT_NULL(res);
 
   //=====Tests for parameters NULL cases=====
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias(NULL, NULL, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_alias_outputs(NULL, NULL, res));
 
   // Test for case without query params
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, NULL, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, NULL, res));
   TEST_ASSERT(res->is_error == false);
 
   outputs_query_list_t* list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_alias) == 0);
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_alias(&ctx, list, NULL));
+  TEST_ASSERT_EQUAL_INT(-1, get_alias_outputs(&ctx, list, NULL));
 
   //=====Test invalid address len=====
   res_outputs_free(res);
@@ -331,7 +331,7 @@ void test_get_alias_outputs() {
   list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_hex_invalid_length) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
@@ -346,7 +346,7 @@ void test_get_alias_outputs() {
   list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_hex_invalid) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
@@ -361,7 +361,7 @@ void test_get_alias_outputs() {
   list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_STATE_CTRL, addr_alias) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   //=====Test issuer address=====
@@ -370,7 +370,7 @@ void test_get_alias_outputs() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ISSUER, addr_alias) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   //=====Test Page Size=====
@@ -379,7 +379,7 @@ void test_get_alias_outputs() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_PAGE_SIZE, "2") == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   //=====Test Cursor=====
@@ -388,7 +388,7 @@ void test_get_alias_outputs() {
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_CURSOR, cursor) == 0);
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_alias(&ctx, list, res));
+  TEST_ASSERT_EQUAL_INT(0, get_alias_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   res_outputs_free(res);

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -119,10 +119,12 @@ void test_deser_outputs_err() {
 
 void test_get_output_ids() {
   char addr[] = "atoi1qpl4a3k3dep7qmw4tdq3pss6ld40jr5yhaq4fjakxgmdgk238j5hzsk2xsk";
+  char dust_ret_addr[] = "atoi1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluehe53e";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length =
       "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
+  char const* const tag = "4ec7f23a";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();
@@ -205,6 +207,47 @@ void test_get_output_ids() {
   TEST_ASSERT_NOT_NULL(res);
 
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_CURSOR, cursor) == 0);
+  ret = get_outputs_id(&ctx, list, res);
+  TEST_ASSERT(ret == 0);
+  TEST_ASSERT(res->is_error == false);
+
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+
+  // TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "true") == 0);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET, "false") == 0);
+  ret = get_outputs_id(&ctx, list, res);
+  TEST_ASSERT(ret == 0);
+  TEST_ASSERT(res->is_error == false);
+
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_DUST_RET_ADDR, dust_ret_addr) == 0);
+  ret = get_outputs_id(&ctx, list, res);
+  TEST_ASSERT(ret == 0);
+  TEST_ASSERT(res->is_error == false);
+
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_SENDER, addr) == 0);
+  ret = get_outputs_id(&ctx, list, res);
+  TEST_ASSERT(ret == 0);
+  TEST_ASSERT(res->is_error == false);
+
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_TAG, tag) == 0);
   ret = get_outputs_id(&ctx, list, res);
   TEST_ASSERT(ret == 0);
   TEST_ASSERT(res->is_error == false);

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -489,48 +489,89 @@ void test_get_alias_outputs() {
   outputs_query_list_free(list);
 }
 
-void test_get_output_ids_from_foundry_address() {
-  char addr_foundry[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
+void test_get_foundry_outputs() {
+  char addr_alias[] = "atoi1zpk6m4x7m2t6k5pvgs0yd2nqelfaz09ueyyv6fwn";
   char const* const addr_hex_invalid = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   char const* const addr_hex_invalid_length = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  char const* const cursor = "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   iota_client_conf_t ctx = {.host = TEST_NODE_HOST, .port = TEST_NODE_PORT, .use_tls = TEST_IS_HTTPS};
 
   res_outputs_id_t* res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
 
   //=====Tests for parameters NULL cases=====
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_foundry_address(NULL, addr_foundry, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_foundry_address(&ctx, NULL, res));
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_foundry_address(&ctx, addr_foundry, NULL));
+  outputs_query_list_t* list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr_alias) == 0);
+  TEST_ASSERT_EQUAL_INT(-1, get_foundry_outputs(NULL, list, res));
+  TEST_ASSERT_EQUAL_INT(-1, get_foundry_outputs(&ctx, list, NULL));
+
+  //=====Test without query params=====
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, NULL, res));
+  TEST_ASSERT(res->is_error == false);
 
   //=====Test invalid address len=====
-  TEST_ASSERT_EQUAL_INT(-1, get_outputs_from_foundry_address(&ctx, addr_hex_invalid_length, res));
-
-  // Re initializing res
   res_outputs_free(res);
   res = NULL;
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
-
-  //=====Test invalid alias address=====
-  TEST_ASSERT_EQUAL_INT(0, get_outputs_from_foundry_address(&ctx, addr_hex_invalid, res));
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr_hex_invalid_length) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error);
   if (res->is_error == true) {
     printf("Error: %s\n", res->u.error->msg);
   }
 
-  // Re initializing res
+  //=====Test invalid alias address=====
   res_outputs_free(res);
   res = NULL;
   res = res_outputs_new();
   TEST_ASSERT_NOT_NULL(res);
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr_hex_invalid) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, list, res));
+  TEST_ASSERT(res->is_error);
+  if (res->is_error == true) {
+    printf("Error: %s\n", res->u.error->msg);
+  }
 
   //=====Test valid alias address=====
-  int ret = get_outputs_from_foundry_address(&ctx, addr_foundry, res);
-  TEST_ASSERT(ret == 0);
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  outputs_query_list_free(list);
+  list = outputs_query_list_new();
+  TEST_ASSERT_NULL(list);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr_alias) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, list, res));
+  TEST_ASSERT(res->is_error == false);
+
+  //=====Test page size=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_PAGE_SIZE, "2") == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, list, res));
+  TEST_ASSERT(res->is_error == false);
+
+  //=====Test Cursor=====
+  res_outputs_free(res);
+  res = NULL;
+  res = res_outputs_new();
+  TEST_ASSERT_NOT_NULL(res);
+  TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_CURSOR, cursor) == 0);
+  TEST_ASSERT_EQUAL_INT(0, get_foundry_outputs(&ctx, list, res));
   TEST_ASSERT(res->is_error == false);
 
   res_outputs_free(res);
+  outputs_query_list_free(list);
 }
 
 void test_get_output_ids_from_nft_id() {
@@ -678,7 +719,7 @@ int main() {
   RUN_TEST(test_get_output_ids);
   RUN_TEST(test_get_nft_output);
   RUN_TEST(test_get_alias_outputs);
-  RUN_TEST(test_get_output_ids_from_foundry_address);
+  RUN_TEST(test_get_foundry_outputs);
   RUN_TEST(test_get_output_ids_from_nft_id);
   RUN_TEST(test_get_output_ids_from_alias_id);
   RUN_TEST(test_get_output_ids_from_foundry_id);

--- a/tests/client/api_restful/test_outputs_id.c
+++ b/tests/client/api_restful/test_outputs_id.c
@@ -21,9 +21,15 @@ void test_query_params() {
       "6209d527453cf2b9896146f13fbef94f66883d5e4bfe5600399e9328655fe0850fd3d05a0000.2";
   outputs_query_list_t* list = outputs_query_list_new();
   TEST_ASSERT_NULL(list);
+  // Check len qyery string len for empty list
+  size_t query_str_len = get_outputs_query_str_len(list);
+  TEST_ASSERT_EQUAL(0, query_str_len);
+  char query_str[10];
+  size_t ret = get_outputs_query_str(list, query_str, 10);
+  TEST_ASSERT_EQUAL(0, ret);
   // Add address query parameter
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_ADDRESS, addr) == 0);
-  size_t query_str_len = get_outputs_query_str_len(list);
+  query_str_len = get_outputs_query_str_len(list);
   TEST_ASSERT_EQUAL(72, query_str_len);
   TEST_ASSERT(outputs_query_list_add(&list, QUERY_PARAM_PAGE_SIZE, "2") == 0);
   query_str_len = get_outputs_query_str_len(list);
@@ -34,7 +40,7 @@ void test_query_params() {
   TEST_ASSERT_NOT_EQUAL(0, query_str_len);
   char* buffer = malloc(query_str_len + 1);
   TEST_ASSERT_NOT_NULL(buffer);
-  size_t ret = get_outputs_query_str(list, buffer, query_str_len + 1);
+  ret = get_outputs_query_str(list, buffer, query_str_len + 1);
   TEST_ASSERT_NOT_EQUAL(0, ret);
   TEST_ASSERT_EQUAL(ret, query_str_len + 1);
   printf("Query String : %s\n", buffer);


### PR DESCRIPTION
# Description of change

Fixes #287 
- Added query params for getting basic, nft, alias and foundry outputs.
### Added Query Params :
- address
- hasDustReturnCondition
- dustReturnAddress
- sender
- tag
- pageSize
- cursor
- stateController
- governor
- issuer

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

test_outputs_id.c

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
