### PR TITLE
Fix - UTXO Input Duplicate Check

### DIFF
--- a/src/core/models/inputs/utxo_input.c
+++ b/src/core/models/inputs/utxo_input.c
@@ -46,15 +46,13 @@ int utxo_inputs_add(utxo_inputs_list_t **inputs, uint8_t type, byte_t id[], uint
   }
 
   // Check if transaction id already exist in list
-  if (utxo_inputs_find_by_id(*inputs, id) != NULL) {
-    printf("[%s:%d] transaction id already present in input list\n", __func__, __LINE__);
-    return -1;
-  }
-
-  // Check if index already exist in list
-  if (utxo_inputs_find_by_index(*inputs, index) != NULL) {
-    printf("[%s:%d] index already present in input list\n", __func__, __LINE__);
-    return -1;
+  utxo_input_t *input = utxo_inputs_find_by_id(*inputs, id);
+  if (input != NULL) {
+    // Check if the duplicate transaction id has the same index,if not we can ignore
+    if (input->output_index == index) {
+      printf("[%s:%d] duplicate transaction id and output index combination present in the list\n", __func__, __LINE__);
+      return -1;
+    }
   }
 
   utxo_inputs_list_t *next = malloc(sizeof(utxo_inputs_list_t));

--- a/tests/core/test_inputs.c
+++ b/tests/core/test_inputs.c
@@ -56,13 +56,16 @@ void test_utxo_input() {
   // Check if count of inputs is 3
   TEST_ASSERT_EQUAL_UINT16(3, utxo_inputs_count(inputs));
 
-  // trying to add txn id that is already present in list
-  TEST_ASSERT(utxo_inputs_add(&inputs, 0, tx_id1, 4) == -1);
+  // trying to add txn id that is already present in list but with non existing index
+  TEST_ASSERT(utxo_inputs_add(&inputs, 0, tx_id1, 4) == 0);
 
-  // trying to add output index that is present in list
-  TEST_ASSERT(utxo_inputs_add(&inputs, 0, tx_id3, 2) == -1);
+  // trying to add a new txn_id with output index that is present in list
+  TEST_ASSERT(utxo_inputs_add(&inputs, 0, tx_id3, 2) == 0);
 
-  // print utxo inputs list with 3 inputs
+  // trying to add txn_id and output index that is present in the list in the same input
+  TEST_ASSERT(utxo_inputs_add(&inputs, 0, tx_id2, 3) == -1);
+
+  // print utxo inputs list with 5 inputs
   utxo_inputs_print(inputs, 0);
 
   // find and validate transaction ID
@@ -99,7 +102,7 @@ void test_utxo_input() {
   TEST_ASSERT_NOT_NULL(deser_inputs);
 
   // Validate input count
-  TEST_ASSERT_EQUAL_INT(3, utxo_inputs_count(deser_inputs));
+  TEST_ASSERT_EQUAL_INT(5, utxo_inputs_count(deser_inputs));
 
   // find and validate index
   elm = utxo_inputs_find_by_index(deser_inputs, 3);


### PR DESCRIPTION
# Description of change

UTXO Input Checking duplicate combination of transaction ID and index.

## Type of change

- Bugfix (a non-breaking change which fixes an issue)

## How the change has been tested

test_inputs.c

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
