### PR TITLE
Core - Removed obsolete bech32 methods

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -25,7 +25,7 @@ The Core API is low level API implementation based on [iotaledger/protocol-rfcs]
 ```
 
 ```{eval-rst}
-.. doxygenfunction:: address_2_bech32
+.. doxygenfunction:: address_to_bech32
 ```
 
 ```{eval-rst}
@@ -301,11 +301,15 @@ The Core API is low level API implementation based on [iotaledger/protocol-rfcs]
 ### [Bech32](https://github.com/iotaledger/iota.c/blob/dev/src/core/utils/bech32.h)
 
 ```{eval-rst}
-.. doxygenfunction:: address_to_bech32
+.. doxygenfunction:: bech32_encode
 ```
 
 ```{eval-rst}
-.. doxygenfunction:: address_from_bech32
+.. doxygenfunction:: bech32_decode
+```
+
+```{eval-rst}
+.. doxygenfunction:: bech32_convert_bits
 ```
 
 ### [Slip10](https://github.com/iotaledger/iota.c/blob/dev/src/core/utils/slip10.h)

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -301,11 +301,11 @@ The Core API is low level API implementation based on [iotaledger/protocol-rfcs]
 ### [Bech32](https://github.com/iotaledger/iota.c/blob/dev/src/core/utils/bech32.h)
 
 ```{eval-rst}
-.. doxygenfunction:: iota_addr_bech32_encode
+.. doxygenfunction:: address_to_bech32
 ```
 
 ```{eval-rst}
-.. doxygenfunction:: iota_addr_bech32_decode
+.. doxygenfunction:: address_from_bech32
 ```
 
 ### [Slip10](https://github.com/iotaledger/iota.c/blob/dev/src/core/utils/slip10.h)

--- a/src/core/utils/bech32.c
+++ b/src/core/utils/bech32.c
@@ -160,39 +160,3 @@ int bech32_decode(char *hrp, uint8_t *data, size_t *data_len, const char *input)
   }
   return chk == 1;
 }
-
-int iota_addr_bech32_encode(char *output, const char *hrp, const uint8_t *addr, size_t addr_len) {
-  uint8_t data[64];
-  size_t datalen = 0;
-  bech32_convert_bits(data, &datalen, 5, addr, addr_len, 8, 1);
-  return bech32_encode(output, hrp, data, datalen);
-}
-
-int iota_addr_bech32_decode(uint8_t *addr_data, size_t *addr_len, const char *hrp, const char *addr_str) {
-  uint8_t data[64];
-  char hrp_actual[84];
-  size_t data_len = 0;
-
-  if (!bech32_decode(hrp_actual, data, &data_len, addr_str)) {
-    return 0;
-  }
-
-  if (data_len == 0 || data_len > 64) {
-    return 0;
-  }
-
-  if (strncmp(hrp, hrp_actual, 84) != 0) {
-    return 0;
-  }
-
-  // 0 is denoted as ED25519 address type
-  if (data[0] != 0) {
-    return 0;
-  }
-
-  *addr_len = 0;
-  if (!bech32_convert_bits(addr_data, addr_len, 8, data, data_len, 5, 0)) {
-    return 0;
-  }
-  return 1;
-}

--- a/src/core/utils/bech32.h
+++ b/src/core/utils/bech32.h
@@ -48,28 +48,6 @@ int bech32_decode(char *hrp, uint8_t *data, size_t *data_len, const char *input)
 int bech32_convert_bits(uint8_t *out, size_t *outlen, int outbits, const uint8_t *in, size_t inlen, int inbits,
                         int pad);
 
-/**
- * @brief Encode IOTA address to bech32 string
- *
- * @param[out] output An output buffer holds bech32 address string
- * @param[in] hrp A string of human-readable prefixe
- * @param[in] addr An address in bytes
- * @param[in] addr_len The length of IOTA address which is 33
- * @return int 1 on success
- */
-int iota_addr_bech32_encode(char *output, const char *hrp, const uint8_t *addr, size_t addr_len);
-
-/**
- * @brief Decode a bech32 string to address byte data
- *
- * @param[out] addr_data A buffer holds the address byte data
- * @param[out] addr_len the number bytes of address data
- * @param[in] hrp An expected string of human-readable prefixe
- * @param[in] addr_str A string of bech32 address
- * @return int 1 on success
- */
-int iota_addr_bech32_decode(uint8_t *addr_data, size_t *addr_len, const char *hrp, const char *addr_str);
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/core/test_utils_bech32.c
+++ b/tests/core/test_utils_bech32.c
@@ -65,33 +65,10 @@ void test_bech32_decode_encode() {
   }
 }
 
-void test_bech32_iota_decode_encode() {
-  char const *const exp_bech32 = "iot1qxrazekjt3x0720cnvwl9usnf2tmery36hlpl95kpmwedxhss0u5cwx3txe";
-  // address verion + address data = 33 bytes
-  byte_t exp_addr[33] = {0x01, 0x87, 0xd1, 0x66, 0xd2, 0x5c, 0x4c, 0xff, 0x29, 0xf8, 0x9b,
-                         0x1d, 0xf2, 0xf2, 0x13, 0x4a, 0x97, 0xbc, 0x8c, 0x91, 0xd5, 0xfe,
-                         0x1f, 0x96, 0x96, 0x0e, 0xdd, 0x96, 0x9a, 0xf0, 0x83, 0xf9, 0x4c};
-
-  // decode
-  byte_t tmp_addr[33] = {};
-  size_t len = 0;
-  TEST_ASSERT(iota_addr_bech32_decode(tmp_addr, &len, "iot", exp_bech32) == 1);
-  TEST_ASSERT_EQUAL_UINT32(sizeof(exp_addr), len);
-  TEST_ASSERT_EQUAL_MEMORY(exp_addr, tmp_addr, sizeof(exp_addr));
-  // dump_hex(tmp_addr, len);
-
-  // encode
-  char tmp_bech32_addr[64] = {};
-  TEST_ASSERT(iota_addr_bech32_encode(tmp_bech32_addr, "iot", exp_addr, sizeof(exp_addr)) == 1);
-  TEST_ASSERT_EQUAL_STRING(exp_bech32, tmp_bech32_addr);
-  // printf("%s\n", tmp_bech32_addr);
-}
-
 int main() {
   UNITY_BEGIN();
 
   RUN_TEST(test_bech32_decode_encode);
-  RUN_TEST(test_bech32_iota_decode_encode);
 
   return UNITY_END();
 }


### PR DESCRIPTION
# Description of change

Fixes #301 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests for `address_to_bech32` and `address_from_bech32` functions which replace removed functions (`iota_addr_bech32_encode` and `iota_addr_bech32_decode`) already exists, so no new unit tests were implemented.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
