### PR TITLE
Core - Add Verification for Shimmer Coin and Its Bech32 HRP

### DIFF
--- a/src/client/api/restful/get_output.c
+++ b/src/client/api/restful/get_output.c
@@ -160,7 +160,7 @@ int get_output(iota_client_conf_t const *conf, char const output_id[], res_outpu
     return -1;
   }
 
-  if (strlen(output_id) != IOTA_OUTPUT_ID_HEX_BYTES) {
+  if (strlen(output_id) != BIN_TO_HEX_BYTES(IOTA_OUTPUT_ID_BYTES)) {
     // invalid output id length
     printf("[%s:%d]: invalid output id length: %zu\n", __func__, __LINE__, strlen(output_id));
     return -1;

--- a/src/client/api/restful/get_output.h
+++ b/src/client/api/restful/get_output.h
@@ -14,9 +14,6 @@
 #include "core/models/message.h"
 #include "core/models/outputs/outputs.h"
 
-// output id = transaction id(64 bytes) + output index(4 bytes)
-#define IOTA_OUTPUT_ID_HEX_BYTES 68
-
 /**
  * @brief An output response object
  *

--- a/src/core/address.c
+++ b/src/core/address.c
@@ -10,11 +10,6 @@
 #include "core/utils/macros.h"
 #include "core/utils/slip10.h"
 
-static int address_from_ed25519_pub(byte_t const pub_key[], address_t *addr) {
-  addr->type = ADDRESS_TYPE_ED25519;
-  return iota_blake2b_sum(pub_key, ED_PUBLIC_KEY_BYTES, addr->address, ED25519_PUBKEY_BYTES);
-}
-
 int address_keypair_from_path(byte_t seed[], size_t seed_len, char path[], ed25519_keypair_t *keypair) {
   // derive key from seed
   slip10_key_t key = {};
@@ -52,6 +47,11 @@ int ed25519_address_from_path(byte_t seed[], size_t seed_len, char path[], addre
     return -1;
   }
   return address_from_ed25519_pub(addr_keypair.pub, addr);
+}
+
+int address_from_ed25519_pub(byte_t const pub_key[], address_t *addr) {
+  addr->type = ADDRESS_TYPE_ED25519;
+  return iota_blake2b_sum(pub_key, ED_PUBLIC_KEY_BYTES, addr->address, ED25519_PUBKEY_BYTES);
 }
 
 int alias_address_from_output(byte_t const output_id[], uint8_t output_id_len, address_t *addr) {

--- a/src/core/address.c
+++ b/src/core/address.c
@@ -50,6 +50,10 @@ int ed25519_address_from_path(byte_t seed[], size_t seed_len, char path[], addre
 }
 
 int address_from_ed25519_pub(byte_t const pub_key[], address_t *addr) {
+  if (pub_key == NULL || addr == NULL) {
+    return -1;
+  }
+
   addr->type = ADDRESS_TYPE_ED25519;
   return iota_blake2b_sum(pub_key, ED_PUBLIC_KEY_BYTES, addr->address, ED25519_PUBKEY_BYTES);
 }

--- a/src/core/address.h
+++ b/src/core/address.h
@@ -77,6 +77,15 @@ int address_keypair_from_path(byte_t seed[], size_t seed_len, char path[], ed255
 int ed25519_address_from_path(byte_t seed[], size_t seed_len, char path[], address_t *addr);
 
 /**
+ * @brief Derive ed25519 address from ed25519 public key
+ *
+ * @param[in] pub_key An ed25519 public key
+ * @param[out] addr An ed25519 address object
+ * @return int 0 on success
+ */
+int address_from_ed25519_pub(byte_t const pub_key[], address_t *addr);
+
+/**
  * @brief Derive an Alias address from output ID
  *
  * @param[in] output_id A output ID byte array

--- a/tests/client/api_restful/test_send_message.c
+++ b/tests/client/api_restful/test_send_message.c
@@ -205,16 +205,15 @@ void test_send_msg_tx_basic() {
   TEST_ASSERT(ed25519_address_from_path(mnemonic_seed, sizeof(mnemonic_seed), "m/44'/4218'/0'/0'/0'", &addr_send) == 0);
   TEST_ASSERT(ed25519_address_from_path(mnemonic_seed, sizeof(mnemonic_seed), "m/44'/4218'/0'/0'/1'", &addr_recv) == 0);
 
-  char const* const hrp = "atoi";
-  address_to_bech32(&addr_send, hrp, bech32_sender, sizeof(bech32_sender));
-  address_to_bech32(&addr_recv, hrp, bech32_receiver, sizeof(bech32_receiver));
-  printf("sender: %s\nreceiver: %s\n", bech32_sender, bech32_receiver);
-
-  // Get info from a node and set correct network ID in protocol version
+  // Get info from a node
   res_node_info_t* info = res_node_info_new();
   int ret = get_node_info(&ctx, info);
   TEST_ASSERT_EQUAL_INT(0, ret);
   TEST_ASSERT_FALSE(info->is_error);
+
+  address_to_bech32(&addr_send, info->u.output_node_info->bech32hrp, bech32_sender, sizeof(bech32_sender));
+  address_to_bech32(&addr_recv, info->u.output_node_info->bech32hrp, bech32_receiver, sizeof(bech32_receiver));
+  printf("sender: %s\nreceiver: %s\n", bech32_sender, bech32_receiver);
 
   // Set correct protocol version and network ID
   uint8_t ver = info->u.output_node_info->protocol_version;

--- a/tests/core/test_address.c
+++ b/tests/core/test_address.c
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <inttypes.h>
-#include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
 
 #include "core/address.h"
 #include "core/utils/byte_buffer.h"
@@ -47,6 +45,37 @@ void test_ed25519_gen_from_seed_iota_network() {
   TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
 }
 
+void test_ed25519_gen_from_seed_iota_test_network() {
+  byte_t exp_addr[] = {0x00, 0x51, 0x55, 0x82, 0xfe, 0x64, 0x8b, 0xf,  0x10, 0xa2, 0xb2,
+                       0xa1, 0xb9, 0x1d, 0x75, 0x2,  0x19, 0xc,  0x97, 0x9b, 0xaa, 0xbf,
+                       0xee, 0x85, 0xb6, 0xbb, 0xb5, 0x2,  0x6,  0x92, 0xe5, 0x5d, 0x16};
+  address_t ed25519_addr = {};
+  byte_t seed[32] = {};
+  byte_t ed25519_serialized[33] = {};
+  char bech32_str[65] = {};
+  // convert seed from hex string to binary
+  TEST_ASSERT(hex_2_bin("e57fb750f3a3a67969ece5bd9ae7eef5b2256a818b2aac458941f7274985a410", 64, NULL, seed, 32) == 0);
+  // dump_hex(seed, 32);
+
+  TEST_ASSERT(ed25519_address_from_path(seed, sizeof(seed), "m/44'/4218'/0'/0'/0'", &ed25519_addr) == 0);
+  // dump_hex(ed25519_addr.address, 32);
+  size_t ser_len = address_serialize(&ed25519_addr, ed25519_serialized, sizeof(ed25519_serialized));
+  TEST_ASSERT(ser_len == address_serialized_len(&ed25519_addr));
+  // dump_hex(ed25519_serialized, ser_len);
+  TEST_ASSERT_EQUAL_MEMORY(exp_addr, ed25519_serialized, ser_len);
+
+  // convert binary address to bech32 with atoi HRP
+  char const* const exp_atoi_bech32 = "atoi1qpg4tqh7vj9s7y9zk2smj8t4qgvse9um42l7apdkhw6syp5ju4w3vet6gtj";
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT_EQUAL_STRING(exp_atoi_bech32, bech32_str);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  // bech32 to address object
+  address_t from_bech32 = {};
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+}
+
 void test_ed25519_gen_from_seed_shimmer_network() {
   byte_t exp_addr[] = {0x0,  0xb5, 0x77, 0x99, 0xbf, 0x74, 0xe,  0x89, 0x46, 0xfe, 0x4a,
                        0x31, 0xf4, 0xcf, 0x37, 0x66, 0x38, 0x4a, 0xd4, 0xe2, 0x47, 0x22,
@@ -75,6 +104,37 @@ void test_ed25519_gen_from_seed_shimmer_network() {
   // bech32 to address object
   address_t from_bech32 = {};
   TEST_ASSERT(address_from_bech32("smr", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+}
+
+void test_ed25519_gen_from_seed_shimmer_test_network() {
+  byte_t exp_addr[] = {0x0,  0xb5, 0x77, 0x99, 0xbf, 0x74, 0xe,  0x89, 0x46, 0xfe, 0x4a,
+                       0x31, 0xf4, 0xcf, 0x37, 0x66, 0x38, 0x4a, 0xd4, 0xe2, 0x47, 0x22,
+                       0xb1, 0x54, 0xc,  0x62, 0x3a, 0x44, 0x84, 0x6d, 0xe,  0x75, 0xa0};
+  address_t ed25519_addr = {};
+  byte_t seed[32] = {};
+  byte_t ed25519_serialized[33] = {};
+  char bech32_str[65] = {};
+  // convert seed from hex string to binary
+  TEST_ASSERT(hex_2_bin("e57fb750f3a3a67969ece5bd9ae7eef5b2256a818b2aac458941f7274985a410", 64, NULL, seed, 32) == 0);
+  // dump_hex(seed, 32);
+
+  TEST_ASSERT(ed25519_address_from_path(seed, sizeof(seed), "m/44'/4219'/0'/0'/0'", &ed25519_addr) == 0);
+  // dump_hex(ed25519_addr.address, 32);
+  size_t ser_len = address_serialize(&ed25519_addr, ed25519_serialized, sizeof(ed25519_serialized));
+  TEST_ASSERT(ser_len == address_serialized_len(&ed25519_addr));
+  // dump_hex(ed25519_serialized, ser_len);
+  TEST_ASSERT_EQUAL_MEMORY(exp_addr, ed25519_serialized, ser_len);
+
+  // convert binary address to bech32 with rms HRP
+  char const* const exp_rms_bech32 = "rms1qz6h0xdlws8gj3h7fgclfnehvcuy448zgu3tz4qvvgayfprdpe66q43s8cc";
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT_EQUAL_STRING(exp_rms_bech32, bech32_str);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  // bech32 to address object
+  address_t from_bech32 = {};
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
   TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
 }
 
@@ -108,6 +168,36 @@ void test_ed25519_gen_iota_network() {
   TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
 }
 
+void test_ed25519_gen_iota_test_network() {
+  // ed25519 address
+  address_t ed25519_addr = {};
+  ed25519_addr.type = ADDRESS_TYPE_ED25519;
+  TEST_ASSERT(hex_2_bin("efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3",
+                        BIN_TO_HEX_BYTES(ED25519_PUBKEY_BYTES), NULL, ed25519_addr.address, ED25519_PUBKEY_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+
+  // create ed25519 address from public key
+  byte_t ed25519_public_key[ED25519_PUBKEY_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8",
+                        BIN_TO_HEX_BYTES(ED25519_PUBKEY_BYTES), NULL, ed25519_public_key, ED25519_PUBKEY_BYTES) == 0);
+  TEST_ASSERT(address_from_ed25519_pub(ed25519_public_key, &ed25519_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6x8x4r7t", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+}
+
 void test_ed25519_gen_shimmer_network() {
   // ed25519 address
   address_t ed25519_addr = {};
@@ -135,6 +225,36 @@ void test_ed25519_gen_shimmer_network() {
   // printf("bech32 [smr]: %s\n", bech32_str);
 
   TEST_ASSERT(address_from_bech32("smr", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+}
+
+void test_ed25519_gen_shimmer_test_network() {
+  // ed25519 address
+  address_t ed25519_addr = {};
+  ed25519_addr.type = ADDRESS_TYPE_ED25519;
+  TEST_ASSERT(hex_2_bin("efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3",
+                        BIN_TO_HEX_BYTES(ED25519_PUBKEY_BYTES), NULL, ed25519_addr.address, ED25519_PUBKEY_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
+
+  // create ed25519 address from public key
+  byte_t ed25519_public_key[ED25519_PUBKEY_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("6f1581709bb7b1ef030d210db18e3b0ba1c776fba65d8cdaad05415142d189f8",
+                        BIN_TO_HEX_BYTES(ED25519_PUBKEY_BYTES), NULL, ed25519_public_key, ED25519_PUBKEY_BYTES) == 0);
+  TEST_ASSERT(address_from_ed25519_pub(ed25519_public_key, &ed25519_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&ed25519_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1qrhacyfwlcnzkvzteumekfkrrwks98mpdm37cj4xx3drvmjvnep6xrlkcfw", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
   TEST_ASSERT(address_equal(&ed25519_addr, &from_bech32) == true);
 }
 
@@ -168,6 +288,36 @@ void test_alias_gen_iota_network() {
   TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
 }
 
+void test_alias_gen_iota_test_network() {
+  // alias address
+  address_t alias_addr = {};
+  alias_addr.type = ADDRESS_TYPE_ALIAS;
+  TEST_ASSERT(hex_2_bin("6457f5f1bc2c3ec696889309cee0665c298f6394", BIN_TO_HEX_BYTES(ALIAS_ID_BYTES), NULL,
+                        alias_addr.address, ALIAS_ID_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&alias_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
+
+  // create alias address from output ID
+  byte_t output_id[IOTA_OUTPUT_ID_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000",
+                        BIN_TO_HEX_BYTES(IOTA_OUTPUT_ID_BYTES), NULL, output_id, IOTA_OUTPUT_ID_BYTES) == 0);
+  TEST_ASSERT(alias_address_from_output(output_id, sizeof(output_id), &alias_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&alias_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1ppj90a03hskra35k3zfsnnhqvewznrmrjstev296", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
+}
+
 void test_alias_gen_shimmer_network() {
   // alias address
   address_t alias_addr = {};
@@ -195,6 +345,36 @@ void test_alias_gen_shimmer_network() {
   // printf("bech32 [smr]: %s\n", bech32_str);
 
   TEST_ASSERT(address_from_bech32("smr", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
+}
+
+void test_alias_gen_shimmer_test_network() {
+  // alias address
+  address_t alias_addr = {};
+  alias_addr.type = ADDRESS_TYPE_ALIAS;
+  TEST_ASSERT(hex_2_bin("6457f5f1bc2c3ec696889309cee0665c298f6394", BIN_TO_HEX_BYTES(ALIAS_ID_BYTES), NULL,
+                        alias_addr.address, ALIAS_ID_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&alias_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
+
+  // create alias address from output ID
+  byte_t output_id[IOTA_OUTPUT_ID_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6490000",
+                        BIN_TO_HEX_BYTES(IOTA_OUTPUT_ID_BYTES), NULL, output_id, IOTA_OUTPUT_ID_BYTES) == 0);
+  TEST_ASSERT(alias_address_from_output(output_id, sizeof(output_id), &alias_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&alias_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1ppj90a03hskra35k3zfsnnhqvewznrmrjskcefsh", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
   TEST_ASSERT(address_equal(&alias_addr, &from_bech32) == true);
 }
 
@@ -228,6 +408,36 @@ void test_nft_gen_iota_network() {
   TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
 }
 
+void test_nft_gen_iota_test_network() {
+  // NFT address
+  address_t nft_addr = {};
+  nft_addr.type = ADDRESS_TYPE_NFT;
+  TEST_ASSERT(hex_2_bin("a1d81f43cc3cc1fe80c594481a63de76eb0d23e1", BIN_TO_HEX_BYTES(NFT_ID_BYTES), NULL,
+                        nft_addr.address, NFT_ID_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&nft_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
+
+  // create NFT address from output ID
+  byte_t output_id[IOTA_OUTPUT_ID_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000",
+                        BIN_TO_HEX_BYTES(IOTA_OUTPUT_ID_BYTES), NULL, output_id, IOTA_OUTPUT_ID_BYTES) == 0);
+  TEST_ASSERT(nft_address_from_output(output_id, sizeof(output_id), &nft_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&nft_addr, "atoi", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("atoi1zzsas86res7vrl5qck2ysxnrmemwkrfruyjqfreg", bech32_str) == 0);
+  // printf("bech32 [atoi]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("atoi", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
+}
+
 void test_nft_gen_shimmer_network() {
   // NFT address
   address_t nft_addr = {};
@@ -255,6 +465,36 @@ void test_nft_gen_shimmer_network() {
   // printf("bech32 [smr]: %s\n", bech32_str);
 
   TEST_ASSERT(address_from_bech32("smr", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
+}
+
+void test_nft_gen_shimmer_test_network() {
+  // NFT address
+  address_t nft_addr = {};
+  nft_addr.type = ADDRESS_TYPE_NFT;
+  TEST_ASSERT(hex_2_bin("a1d81f43cc3cc1fe80c594481a63de76eb0d23e1", BIN_TO_HEX_BYTES(NFT_ID_BYTES), NULL,
+                        nft_addr.address, NFT_ID_BYTES) == 0);
+
+  address_t from_bech32 = {};
+  char bech32_str[65] = {};
+  TEST_ASSERT(address_to_bech32(&nft_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
+  TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
+
+  // create NFT address from output ID
+  byte_t output_id[IOTA_OUTPUT_ID_BYTES] = {0};
+  TEST_ASSERT(hex_2_bin("97b9d84d33419199483daab1f81ddccdeff478b6ee9040cfe026c517f67757880000",
+                        BIN_TO_HEX_BYTES(IOTA_OUTPUT_ID_BYTES), NULL, output_id, IOTA_OUTPUT_ID_BYTES) == 0);
+  TEST_ASSERT(nft_address_from_output(output_id, sizeof(output_id), &nft_addr) == 0);
+
+  TEST_ASSERT(address_to_bech32(&nft_addr, "rms", bech32_str, sizeof(bech32_str)) == 0);
+  TEST_ASSERT(strcmp("rms1zzsas86res7vrl5qck2ysxnrmemwkrfruy0puqv9", bech32_str) == 0);
+  // printf("bech32 [rms]: %s\n", bech32_str);
+
+  TEST_ASSERT(address_from_bech32("rms", bech32_str, &from_bech32) == 0);
   TEST_ASSERT(address_equal(&nft_addr, &from_bech32) == true);
 }
 
@@ -330,13 +570,21 @@ int main() {
   UNITY_BEGIN();
 
   RUN_TEST(test_ed25519_gen_from_seed_iota_network);
+  RUN_TEST(test_ed25519_gen_from_seed_iota_test_network);
   RUN_TEST(test_ed25519_gen_from_seed_shimmer_network);
+  RUN_TEST(test_ed25519_gen_from_seed_shimmer_test_network);
   RUN_TEST(test_ed25519_gen_iota_network);
+  RUN_TEST(test_ed25519_gen_iota_test_network);
   RUN_TEST(test_ed25519_gen_shimmer_network);
+  RUN_TEST(test_ed25519_gen_shimmer_test_network);
   RUN_TEST(test_alias_gen_iota_network);
+  RUN_TEST(test_alias_gen_iota_test_network);
   RUN_TEST(test_alias_gen_shimmer_network);
+  RUN_TEST(test_alias_gen_shimmer_test_network);
   RUN_TEST(test_nft_gen_iota_network);
+  RUN_TEST(test_nft_gen_iota_test_network);
   RUN_TEST(test_nft_gen_shimmer_network);
+  RUN_TEST(test_nft_gen_shimmer_test_network);
   RUN_TEST(test_serializer);
   RUN_TEST(test_clone_equal);
 


### PR DESCRIPTION
# Description of change

- Fixed #386 
- Removed unneeded `IOTA_OUTPUT_ID_HEX_BYTES` define
- Made function `address_from_ed25519_pub` public

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

New unit tests are in  `tests/core/test_address.c`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests using CTest that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
